### PR TITLE
Add sniffable-python skill: structure code for LLM comprehension

### DIFF
--- a/PROTOCOLS.yml
+++ b/PROTOCOLS.yml
@@ -2312,6 +2312,54 @@ SISTER-SCRIPT:
     # Script → Document: Automation insights improve docs
   wisdom: "The document is the source of truth. Scripts are its children."
 
+SNIFFABLE-PYTHON:
+  meaning: "Structure Python so LLMs can understand it in 50 lines."
+  location: skills/sniffable-python/
+  invoke_when: "Generating Python CLI tools, reading scripts efficiently"
+  
+  anti_compression: |
+    # Don't invent new syntax — STRUCTURE existing syntax.
+    # The LLM already knows Python cold. Zero tokens to teach.
+    # Novel syntax costs millions of tokens per context (docs, examples, corrections).
+    # Sniffable Python costs zero — the LLM just reads code it understands.
+    #
+    # Perl's obsessive fetish for compact syntax, sigils, and punctuation
+    # is exactly why it's no longer relevant for LLM generation.
+    # Dense symbols are anti-optimized for how transformers reason.
+    
+  structure: |
+    # The canonical zones of a sniffable Python file:
+    #
+    # Lines 1-15:  Shebang + Docstring (becomes --help)
+    # Lines 16-22: Imports (dependencies at a glance)
+    # Lines 23-30: Constants (config with explanatory comments)
+    # Lines 31-50: CLI Structure (command tree with types)
+    # Lines 51+:   Implementation (below the fold)
+    #
+    # LLM reads first 50 lines → understands the API.
+    # Human runs --help → same source of truth.
+    
+  dual_audience: |
+    # Same file serves two audiences:
+    # - Human: runs `./tool.py --help`
+    # - LLM: reads first 50 lines of source
+    # DRY: CLI decorators ARE the documentation
+    
+  yaml_jazz_for_python: |
+    # Apply YAML-JAZZ principles to Python comments:
+    # 
+    # TIMEOUT = 30  # generous — API is flaky on Mondays
+    # RETRIES = 3   # based on observed failure patterns
+    #
+    # Comments are data. The LLM reads them. Acts on them.
+    
+  thesis: |
+    # Comprehension fidelity > token count.
+    # You don't need fewer tokens of unfamiliar syntax.
+    # You need familiar syntax, structured for fast comprehension.
+    
+  see_also: [SISTER-SCRIPT, YAML-JAZZ, SKILL]
+
 BUILD-COMMAND:
   meaning: "Collaborative planning to create sister apps from slow LLM sequences."
   location: temp/lloooomm/01-Projects/lloooomm/vm/lloooomm.md#build-command
@@ -2508,7 +2556,7 @@ _categories:
   interpretation: [POSTEL, CHARITY, PROCEDURAL-RHETORIC, MASKING-EFFECT, SIMULATOR-EFFECT]
   
   # Methodology
-  methodology: [SKILL, PROTOCOL, CONSTRUCTIONISM, PLAY-LEARN-LIFT, SISTER-SCRIPT, BUILD-COMMAND]
+  methodology: [SKILL, PROTOCOL, CONSTRUCTIONISM, PLAY-LEARN-LIFT, SISTER-SCRIPT, SNIFFABLE-PYTHON, BUILD-COMMAND]
   skills: [SKILL, SIP, DOP, PLAN-EXECUTE]
   lifecycle: [YAML-COLTRANE, IMPROVISE, CRYSTALLIZE]
   

--- a/skills/INDEX.yml
+++ b/skills/INDEX.yml
@@ -47,6 +47,17 @@ skills:
     tags: ["meta", "yaml", "semantics"]
     use_when: "Designing YAML files for LLM consumption"
     
+  - name: "sniffable-python"
+    path: "skills/sniffable-python"
+    description: "Structure Python so LLMs can understand it in 50 lines — comprehension over compression"
+    tier: 0
+    entry: "SKILL.md"
+    protocol: "SNIFFABLE-PYTHON"
+    tags: ["meta", "python", "code-structure", "sister-script", "cli"]
+    use_when: "Generating Python CLI tools, structuring scripts for LLM comprehension"
+    related: ["yaml-jazz", "sister-script", "skill", "play-learn-lift"]
+    credits: "MOOLLM — Dual-audience code structure"
+    
   - name: "postel"
     path: "skills/postel"
     description: "Be liberal in what you accept, conservative in what you emit"

--- a/skills/sniffable-python/CARD.yml
+++ b/skills/sniffable-python/CARD.yml
@@ -1,0 +1,156 @@
+# CARD.yml — Sniffable Python Interface
+#
+# Machine-readable interface for the sniffable-python skill.
+# Describes what it can do, when to use it, how to invoke it.
+
+card:
+  id: sniffable-python
+  name: "Sniffable Python"
+  type: [skill, methodology, code-structure]
+  emoji: 🐍
+  tier: 0  # Pure knowledge, no tools required
+  
+  tagline: "Structure code for the first 50 lines."
+  
+  philosophy: |
+    Don't invent new syntax — structure existing syntax.
+    The LLM already knows Python. Leverage that.
+    
+methods:
+  SNIFF:
+    description: "Read and summarize a Python file's API from its header"
+    parameters:
+      file: { type: path, required: true }
+    returns: "API summary: commands, options, purpose"
+    
+  SNIFF-CODE:
+    description: "Language-agnostic sniffability review for ANY source file"
+    parameters:
+      file: { type: path, required: true }
+    returns: "Sniffability report: what's fresh, what's stale"
+    checks:
+      - "Purpose clear from first 10 lines?"
+      - "API/exports before implementation?"
+      - "Semantic comments (WHY not WHAT)?"
+      - "No decorative cruft?"
+      - "Magic values explained?"
+      - "Dependencies visible at top?"
+    languages: ["Python", "TypeScript", "Go", "Rust", "Java", "Bash", "any"]
+    
+  GENERATE-SNIFFABLE:
+    description: "Create new sniffable script from template"
+    parameters:
+      name: { type: string, required: true }
+      purpose: { type: string, required: true }
+      commands: { type: array, required: false }
+    returns: "Path to generated script"
+    
+  VALIDATE-SNIFFABLE:
+    description: "Check if file follows sniffable conventions"
+    parameters:
+      file: { type: path, required: true }
+    returns: "Validation report with issues"
+
+advertisements:
+  # When to suggest this skill
+  
+  PYTHON-SCRIPT-GENERATION:
+    score: 95
+    condition: "Generating a new Python CLI tool"
+    message: "Use sniffable-python structure for LLM comprehension"
+    
+  SCRIPT-COMPREHENSION:
+    score: 90
+    condition: "Need to understand an existing Python script quickly"
+    message: "Sniff the header — first 50 lines contain the API"
+    
+  SISTER-SCRIPT-CREATION:
+    score: 95
+    condition: "Lifting a procedure to an automated script"
+    message: "Sister scripts should follow sniffable-python conventions"
+    
+  ANTI-COMPRESSION:
+    score: 85
+    condition: "Considering novel syntax or dense symbols for LLM optimization"
+    message: "Structure existing syntax instead — Perl's syntax fetish is a cautionary tale"
+
+structure:
+  # The canonical zones of a sniffable Python file
+  
+  zones:
+    - name: "Shebang + Docstring"
+      lines: "1-15"
+      purpose: "Purpose, usage, becomes --help"
+      required: true
+      
+    - name: "Imports"
+      lines: "16-22"
+      purpose: "Dependencies visible at a glance"
+      required: true
+      
+    - name: "Constants"
+      lines: "23-30"
+      purpose: "Configuration with semantic comments (no decorative markers)"
+      required: false
+      
+    - name: "CLI Structure"
+      lines: "31-50"
+      purpose: "main() contains command tree with types and docs"
+      required: true
+      
+    - name: "Implementation"
+      lines: "51+"
+      purpose: "Only read if modifying"
+      required: true
+
+checklist:
+  # What makes a Python file "sniffable"
+  
+  - "Shebang on line 1"
+  - "Module docstring with purpose, usage, examples"
+  - "Imports grouped at top (no decorative markers)"
+  - "Constants with explanatory comments"
+  - "CLI structure in main() using argparse (preferred)"
+  - "Each command has a docstring"
+  - "Types specified in function signatures"
+  - "Implementation below line 50"
+  - "Internal functions prefixed with _"
+
+anti_patterns:
+  - "Implementation before CLI structure"
+  - "No docstrings on commands"
+  - "Magic constants without comments"
+  - "Scattered imports throughout file"
+  - "API not discoverable from header"
+
+dovetails:
+  - skill: sister-script
+    relationship: "Sister scripts should be sniffable"
+    
+  - skill: skill
+    relationship: "Skills generate sniffable scripts"
+    
+  - skill: yaml-jazz
+    relationship: "Comments as semantic data applies to Python"
+    
+  - skill: play-learn-lift
+    relationship: "Scripts emerge from proven procedures, structured for reuse"
+
+protocol_symbol: SNIFFABLE-PYTHON
+invoke_when: "Generating or reading Python scripts that need LLM comprehension"
+
+# The core argument against syntax compression
+thesis: |
+  The "ideal LLM syntax" question has the wrong framing.
+  
+  You don't need new syntax. You need structured familiar syntax.
+  
+  - Languages LLMs know (Python, TypeScript)
+  - Structured for sniffability (important stuff at top)
+  - Comments as data (YAML Jazz applied to Python)
+  - Single source of truth (CLI declarations ARE the spec)
+  
+  Dense syntax (Perl-style sigils, novel compression) is the wrong optimization.
+  Sniffable Python self documenting structures are the right thing.
+  
+  Comprehension fidelity > token count.

--- a/skills/sniffable-python/README.md
+++ b/skills/sniffable-python/README.md
@@ -1,0 +1,79 @@
+# Sniffable Python
+
+> **"Structure code for the first 50 lines. That's all the LLM needs."**
+
+*If your code smells good, the LLM can sniff it from the first whiff.*
+
+Steve Jobs wanted pixels so beautiful you'd want to lick them. We want code so clear you can sniff its purpose from the header.
+
+Python scripts structured so both humans and LLMs can understand them by reading just the header. But the principle applies to **any language** — good code has an aroma that draws you in from the opening lines. Programming languages are user interfaces. The users are humans and LLMs. Lickable pixels invite visual exploration; sniffable code invites structural exploration.
+
+## The Pattern
+
+```python
+#!/usr/bin/env python3
+"""tool-name: One-line description.
+
+This docstring becomes --help AND is visible to the LLM.
+Single source of truth.
+"""
+
+import argparse
+
+VALID_DIRECTIONS = ["north", "south", "east", "west"]
+
+def main():
+    """CLI structure only — no implementation here."""
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    
+    move_parser = subparsers.add_parser("move", help="Move in a direction")
+    move_parser.add_argument("direction", choices=VALID_DIRECTIONS)
+    
+    args = parser.parse_args()
+    _dispatch(args)
+
+# Implementation (LLM only reads past here if needed)
+```
+
+## Why It Works
+
+| Consumer | Discovery Method |
+|----------|------------------|
+| Human | `./tool.py --help` (user runs cli commands in the terminal) |
+| LLM | Read first 50 lines (llm does not need to run it in the terminal) |
+
+Same source of truth. No duplicate documentation. No need to hold your nose.
+
+## SNIFF CODE — Language-Agnostic Review
+
+The `SNIFF CODE` command reviews **any** source file for sniffability:
+
+| What It Checks | Why It Matters |
+|----------------|----------------|
+| Purpose at top? | First impression counts |
+| API before implementation? | Structure over spelunking |
+| Semantic comments? | Comments are data |
+| No decorative cruft? | Every token earns its place |
+
+**Good for Python. Good for TypeScript. Good for Go. Good for humans. Good for LLMs.**
+
+The same conventions that make code sniffable for LLMs make it scannable for humans. We're not optimizing for machines at human expense — we're optimizing for **comprehension**, period.
+
+## Quick Links
+
+- [SKILL.md](./SKILL.md) — Full specification
+- [CARD.yml](./CARD.yml) — Machine-readable interface
+- [TEMPLATE.py.tmpl](./TEMPLATE.py.tmpl) — Starter template
+
+## Related
+
+- [sister-script/](../sister-script/) — Documents that birth scripts
+- [skill/](../skill/) — The meta-skill
+- [yaml-jazz/](../yaml-jazz/) — Comments as data
+
+---
+
+*"The LLM doesn't need to read your whole file. It needs to read the head and know what the file does."*
+
+*Good code doesn't just avoid bad smells — it has a bouquet that invites exploration.*

--- a/skills/sniffable-python/SKILL.md
+++ b/skills/sniffable-python/SKILL.md
@@ -1,0 +1,573 @@
+---
+name: sniffable-python
+description: "Structure Python so LLMs can understand it in 50 lines."
+license: MIT
+tier: 0
+allowed-tools:
+  - read_file
+  - write_file
+related: [sister-script, skill, yaml-jazz, constructionism, play-learn-lift]
+credits:
+  - "MOOLLM — Dual-audience code structure"
+  - "Python argparse — Built-in CLI with clean structure/implementation separation"
+---
+
+# Sniffable Python
+
+> **"Structure code for the first 50 lines. That's all the LLM needs."**
+
+Don't invent new syntax — **structure existing syntax** for optimal LLM comprehension.
+
+*If your code smells good, the LLM can sniff it from the first whiff.*
+
+*Steve Jobs wanted pixels you could lick. We want code you can sniff.*
+
+---
+
+## The Problem
+
+LLMs can read Python. But:
+- Large files overwhelm context
+- Implementation details bury the API
+- Comments scattered or missing
+- No clear entry point for understanding
+
+**Solution:** Structure Python so the first ~50 lines contain everything needed to understand and use the tool. Make your code's bouquet apparent from the opening notes.
+
+---
+
+## The Pattern
+
+### Canonical Structure
+
+```python
+#!/usr/bin/env python3
+"""skill-name: Brief description of what the script does.
+
+This docstring becomes --help output AND is immediately visible to the LLM.
+It should contain:
+- Purpose (one sentence)
+- Usage examples
+- Key behaviors
+
+Usage:
+    python script.py command [options]
+    
+Examples:
+    python script.py move north --quiet
+    python script.py examine sword --verbose
+"""
+
+import argparse
+from pathlib import Path
+import yaml
+
+# Configuration
+DEFAULT_ROOM = "start"
+VALID_DIRECTIONS = ["north", "south", "east", "west"]
+MAX_INVENTORY = 10
+
+def main():
+    """Main entry point — CLI structure only, no implementation."""
+    parser = argparse.ArgumentParser(
+        description=__doc__.split('\n')[0],  # First line of module docstring
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    
+    # move command
+    move_parser = subparsers.add_parser("move", help="Move in a direction")
+    move_parser.add_argument("direction", choices=VALID_DIRECTIONS,
+                             help="Direction to move")
+    move_parser.add_argument("--quiet", "-q", action="store_true",
+                             help="Suppress output")
+    
+    # examine command
+    examine_parser = subparsers.add_parser("examine", help="Look at something")
+    examine_parser.add_argument("target", help="What to examine")
+    examine_parser.add_argument("--verbose", "-v", action="store_true",
+                                help="Show details")
+    
+    # status command
+    status_parser = subparsers.add_parser("status", help="Show game state")
+    status_parser.add_argument("--verbose", "-v", action="store_true",
+                               help="Show details")
+    
+    args = parser.parse_args()
+    _dispatch(args)
+
+# Implementation (LLM only reads past here if modifying behavior)
+
+def _dispatch(args):
+    """Route to appropriate handler."""
+    if args.command == "move":
+        _do_move(args.direction, args.quiet)
+    elif args.command == "examine":
+        _do_examine(args.target, args.verbose)
+    elif args.command == "status":
+        _show_status(args.verbose)
+
+def _do_move(direction: str, quiet: bool) -> None:
+    """Internal: Execute movement."""
+    ...
+
+def _do_examine(target: str, verbose: bool) -> None:
+    """Internal: Examine an object."""
+    ...
+
+def _show_status(verbose: bool) -> None:
+    """Internal: Display status."""
+    ...
+
+if __name__ == "__main__":
+    main()
+```
+
+### The Zones
+
+| Zone | Lines | Purpose |
+|------|-------|---------|
+| **Shebang + Docstring** | 1-15 | Purpose, usage, becomes `--help` |
+| **Imports** | 16-22 | Dependencies visible at a glance |
+| **Constants** | 23-30 | Configuration, valid values, limits |
+| **CLI Structure** | 31-50 | Command tree with types and docs |
+| **Implementation** | 51+ | Only read if modifying |
+
+---
+
+## Why This Works
+
+### Dual-Audience Design
+
+```
+                    ┌─────────────────┐
+                    │   Python File   │
+                    │  (sniffable)    │
+                    └────────┬────────┘
+                             │
+            ┌────────────────┴────────────────┐
+            │                                 │
+            ▼                                 ▼
+    ┌───────────────┐                 ┌───────────────┐
+    │    Human      │                 │     LLM       │
+    │   runs:       │                 │   reads:      │
+    │  --help       │                 │  first 50     │
+    │               │                 │  lines        │
+    └───────────────┘                 └───────────────┘
+            │                                 │
+            └────────────────┬────────────────┘
+                             │
+                             ▼
+                    ┌─────────────────┐
+                    │  Same source    │
+                    │  of truth       │
+                    └─────────────────┘
+```
+
+### DRY Principle
+
+The CLI decorators ARE the documentation:
+
+```python
+@click.option('--verbose', '-v', is_flag=True, help='Show details')
+```
+
+This single line defines:
+- The flag name (`--verbose`)
+- The short form (`-v`)
+- The type (boolean flag)
+- The help text
+- The Python parameter name and type
+
+No duplication. No drift. One source.
+
+---
+
+## Why Syntax Compression Fails
+
+Some argue for compressing syntax to save tokens — dense symbols, sigils, minimal keywords. This is the wrong optimization.
+
+**Perl is the cautionary tale.** Its obsessive fetish for compact syntax, sigils, punctuation, and performative TMTOWTDI one-liners — to the point of looking like line noise — is exactly why it's no longer relevant for LLM comprehension and generation.
+
+| Approach | Tokens | Comprehension | Training Data |
+|----------|--------|---------------|---------------|
+| Dense novel syntax | Fewer | Low (unfamiliar) | Minimal |
+| Sniffable Python | More | High (known syntax) | Billions |
+
+**The LLM already knows Python cold.** Teaching it a novel syntax costs millions of tokens per context window (docs, examples, corrections) — and that cost is paid every single prompt, because prompting is not training. LLMs have no memory. Sniffable Python costs zero tokens to teach — the LLM just reads code it understands deeply from massive pre-training.
+
+### The Symbol Collision Problem
+
+Short symbols cause semantic collisions. When `@` appears, it activates Python decorators, shell patterns, email addresses, and more — simultaneously. The model has to do disambiguation work that wouldn't exist with unambiguous keywords. That disambiguation costs compute and introduces error modes.
+
+### Comprehension Fidelity > Token Count
+
+You're not optimizing for token count. You're optimizing for **how well the LLM understands your code**.
+
+Dense punctuation is anti-optimized for how transformers tokenize and reason. Verbose, well-structured code with semantic comments actually compresses better in the LLM's internal representations.
+
+---
+
+## Comments as YAML Jazz
+
+Apply YAML-JAZZ principles to Python comments:
+
+```python
+# === CONSTANTS ===
+TIMEOUT = 30        # generous — API is flaky on Mondays
+MAX_RETRIES = 3     # based on observed failure patterns in prod
+BATCH_SIZE = 100    # memory-safe for 8GB instances
+
+# TODO: Add circuit breaker after next major outage
+# FIXME: Rate limiting not yet implemented
+# NOTE: This duplicates logic in api_client.py — consider extracting
+```
+
+These comments ARE data. The LLM reads them. Acts on them. Uses them to understand *why*, not just *what*.
+
+---
+
+## Comments: Substance Over Decoration
+
+**Don't waste tokens on decorative separators:**
+
+```python
+# ❌ BAD: Decorative toilet paper
+# ================================================================
+# === IMPORTS ===================================================
+# ================================================================
+import argparse
+
+# ✓ GOOD: Just the content
+# Imports
+import argparse
+```
+
+**Don't trim Christmas trees:**
+
+```python
+# ❌ BAD: ASCII art borders
+#╔══════════════════════════════════════╗
+#║         CONFIGURATION                ║
+#╚══════════════════════════════════════╝
+
+# ✓ GOOD: Plain and functional
+# Configuration
+TIMEOUT = 30  # generous — API flaky on Mondays
+```
+
+**Do include useful semantic comments:**
+
+```python
+# ✓ GOOD: Explains WHY
+TIMEOUT = 30        # generous — API flaky on Mondays
+MAX_RETRIES = 3     # based on observed failure patterns
+BATCH_SIZE = 100    # memory-safe for 8GB instances
+
+# ✓ GOOD: Documents intent
+# TODO: Add circuit breaker after next outage
+# NOTE: Duplicates logic in api_client.py — consider extracting
+```
+
+**The rule:** Every comment token should carry meaning. If it's just decoration, delete it.
+
+---
+
+## Argparse vs Click vs Typer
+
+**Argparse is preferred** for sniffable Python because it separates structure from implementation:
+
+| Feature | Argparse | Click | Typer |
+|---------|----------|-------|-------|
+| Structure/impl separation | ✓ Clean | ✗ Mixed | ✗ Mixed |
+| Top-down tree order | ✓ | ✗ | ✗ |
+| Built-in (no deps) | ✓ | ✗ | ✗ |
+| Training data | Abundant | Abundant | Growing |
+| LLM familiarity | Highest | High | Medium |
+
+### The Argparse Advantage
+
+With Click/Typer, decorators attach to functions — so CLI structure is **interleaved** with implementation:
+
+```python
+# Click: structure mixed with implementation
+@cli.command()
+def examine(target: str):  # ← implementation starts here
+    """Look at something."""
+    do_stuff()  # ← can't sniff without reading this
+```
+
+With argparse, `main()` contains the **entire CLI tree** with no implementation:
+
+```python
+# Argparse: clean separation
+def main():
+    """CLI structure only — no implementation."""
+    parser = argparse.ArgumentParser(description="Tool description")
+    subparsers = parser.add_subparsers(dest="command")
+    
+    # examine command
+    examine_parser = subparsers.add_parser("examine", help="Look at something")
+    examine_parser.add_argument("target", help="What to examine")
+    examine_parser.add_argument("--verbose", "-v", action="store_true")
+    
+    # move command
+    move_parser = subparsers.add_parser("move", help="Move in a direction")
+    move_parser.add_argument("direction", choices=VALID_DIRECTIONS)
+    
+    args = parser.parse_args()
+    _dispatch(args)  # ← implementation is ELSEWHERE
+
+# === IMPLEMENTATION (completely separate, below the fold) ===
+def _dispatch(args):
+    ...
+```
+
+**The LLM reads `main()` and sees the entire command tree** — arguments, types, choices, help text — without any implementation noise. Pure sniffability. No need to hold your nose.
+
+---
+
+## Integration with Sister Scripts
+
+Sniffable Python is how sister scripts should be structured:
+
+```
+skill/
+├── SKILL.md           # Tells LLM how to generate scripts
+├── CARD.yml           # Interface definition
+└── scripts/
+    └── helper.py      # Sniffable Python
+```
+
+When the skill/SKILL.md instructs the LLM to generate a sister script, it should follow sniffable-python conventions:
+
+1. Docstring with usage at top, no decorations
+2. Imports grouped and labeled
+3. Constants with explanatory comments
+4. CLI structure before implementation
+5. Implementation below the fold
+
+---
+
+## The Coherence Engine Flow
+
+```
+User: "Run the room builder for the kitchen"
+                    │
+                    ▼
+    ┌───────────────────────────────────┐
+    │  LLM reads skill/SKILL.md         │
+    │  Discovers: scripts/room-builder  │
+    └───────────────────┬───────────────┘
+                        │
+                        ▼
+    ┌───────────────────────────────────┐
+    │  LLM sniffs room-builder.py       │
+    │  Reads first 50 lines:            │
+    │  - Docstring: "Creates rooms..."  │
+    │  - Commands: create, modify, list │
+    │  - Options: --template, --force   │
+    └───────────────────┬───────────────┘
+                        │
+                        ▼
+    ┌───────────────────────────────────┐
+    │  LLM understands the API          │
+    │  Generates: room-builder create   │
+    │             --template kitchen    │
+    └───────────────────────────────────┘
+```
+
+The LLM discovers the tool's capabilities by reading its structure, not by loading documentation. One quick sniff and it knows what's cooking.
+
+---
+
+## Checklist
+
+When writing sniffable Python:
+
+- [ ] Shebang on line 1
+- [ ] Module docstring with purpose, usage, examples
+- [ ] Imports grouped at top (no decorative markers)
+- [ ] Constants with explanatory comments
+- [ ] CLI structure in `main()` using argparse (preferred) or Click/Typer
+- [ ] Each command has a docstring
+- [ ] Types specified in function signatures
+- [ ] Implementation below line 50
+- [ ] Internal functions prefixed with `_`
+- [ ] `if __name__ == "__main__":` at bottom
+
+---
+
+## Anti-Patterns (Code Smells You Can't Unsmell)
+
+❌ **Implementation before CLI**
+```python
+def _helper():
+    ...
+def _another_helper():
+    ...
+# 200 lines later...
+@click.command()
+def main():
+    ...
+```
+
+❌ **No docstrings**
+```python
+@click.command()
+def process(x, y, z):
+    # What does this do? What are x, y, z?
+```
+
+❌ **Magic constants**
+```python
+if retries > 3:  # Why 3? What happens at 4?
+```
+
+❌ **Scattered imports**
+```python
+import os
+def foo():
+    import json  # Hidden dependency
+```
+
+---
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| `SNIFF [file]` | Read and summarize a Python file's API |
+| `SNIFF CODE [file]` | **Language-agnostic** review for sniffability |
+| `GENERATE-SNIFFABLE [name]` | Create new sniffable script from template |
+| `VALIDATE-SNIFFABLE [file]` | Check if file follows conventions |
+
+### SNIFF CODE — Works on Any Language
+
+The `SNIFF CODE` command isn't Python-specific. It reviews **any** source file:
+
+```
+> SNIFF CODE src/api/handler.ts
+
+Sniffability Report for handler.ts:
+✓ Purpose clear from first 10 lines
+✓ Exports/API visible before implementation  
+✗ Magic number on line 47 — needs comment
+✗ Helper function before main export — reorder
+✓ Semantic comments explain WHY not WHAT
+
+Overall: Mostly fresh, minor reordering needed
+```
+
+**What it checks:**
+
+| Aspect | Question |
+|--------|----------|
+| **Purpose** | Can you understand what this does in 10 lines? |
+| **API-first** | Are exports/interfaces/main before helpers? |
+| **Comments** | Do comments explain WHY, not just WHAT? |
+| **No decoration** | Are comments semantic, not decorative cruft? |
+| **Constants** | Do magic values have explanatory comments? |
+| **Dependencies** | Are imports/requires visible at top? |
+
+**Good for humans. Good for LLMs. Same conventions.**
+
+---
+
+## Protocol Symbol
+
+```
+SNIFFABLE-PYTHON
+```
+
+Invoke when: Generating or reading Python scripts that need to be LLM-comprehensible.
+
+---
+
+## Dovetails With
+
+- **[sister-script/](../sister-script/)** — Scripts generated from documentation
+- **[skill/](../skill/)** — The meta-skill that uses sniffable scripts
+- **[yaml-jazz/](../yaml-jazz/)** — Comments as semantic data
+- **[play-learn-lift/](../play-learn-lift/)** — Scripts emerge from proven procedures
+- **[constructionism/](../constructionism/)** — Building inspectable things
+
+---
+
+## Beyond Python: Universal Sniffability
+
+While this skill focuses on Python, **the principles are language-agnostic**:
+
+| Language | Sniffable Structure |
+|----------|---------------------|
+| **TypeScript** | Exports at top, types before implementation, JSDoc on public API |
+| **Go** | Package doc, exported functions first, internal helpers below |
+| **Rust** | Module doc, pub items at top, private impl below |
+| **Java** | Class Javadoc, public methods before private |
+| **Bash** | Usage comment at top, main at top, functions below |
+
+**The universal rule:** Whatever a reader (human or LLM) needs to *use* the code should be visible before whatever they need to *modify* it.
+
+```typescript
+// ✓ Sniffable TypeScript
+/**
+ * User authentication service.
+ * @module auth
+ */
+
+export interface AuthConfig { ... }
+export function authenticate(config: AuthConfig): Promise<User> { ... }
+export function logout(): void { ... }
+
+// Implementation details below
+function validateToken(token: string): boolean { ... }
+```
+
+**Same smell test, any language:** Can you understand what this code offers by reading just the head?
+
+---
+
+## Lickable Pixels, Sniffable Code
+
+When Steve Jobs unveiled Mac OS X's Aqua interface in 2000, he said:
+
+> *"We made the buttons on the screen look so good you'll want to lick them."*
+
+Jobs understood that interfaces aren't just functional — they should be **sensually inviting**. The translucent droplets, the pulsing default buttons, the candy-colored icons — these weren't decoration. They were signals of quality that drew users in.
+
+**Programming languages are user interfaces.** The users are humans and LLMs. And just as lickable pixels invite visual exploration, **sniffable code invites structural exploration**.
+
+| Lickable Pixels (UI) | Sniffable Code |
+|---------------------|----------------|
+| Visually inviting | Structurally inviting |
+| Draws the eye to affordances | Draws the reader to the API |
+| Beauty signals quality | Clarity signals quality |
+| Users want to click | Readers want to use |
+| First impression matters | First 50 lines matter |
+
+Jobs didn't make Aqua pretty at the expense of function — the visual design *reinforced* usability. Sniffable code works the same way: the structural clarity that helps LLMs also helps humans. We're not optimizing for machines at human expense. We're optimizing for **comprehension**, and both benefit.
+
+*Perl looks like line noise. Sniffable Python looks like an invitation.*
+
+---
+
+## The Thesis
+
+The "ideal LLM syntax" question has the wrong framing.
+
+You don't need new syntax. You need **structured familiar syntax**.
+
+- Languages LLMs know (Python, TypeScript, Go, Rust...)
+- Structured for sniffability (important stuff at top)
+- Comments as data (YAML Jazz applied to any language)
+- Single source of truth (the code IS the spec)
+
+Dense syntax compresses the wrong thing. Sniffable code structures the right thing.
+
+*Jobs made you want to lick the screen. We want you to sniff the source.*
+
+---
+
+*"The LLM doesn't need fewer tokens of unfamiliar syntax. It needs familiar syntax, structured for fast comprehension."*
+
+*Good code doesn't just avoid bad smells — it has an aroma that draws you in from the header.*

--- a/skills/sniffable-python/TEMPLATE.py.tmpl
+++ b/skills/sniffable-python/TEMPLATE.py.tmpl
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""{{name}}: {{purpose}}
+
+{{description}}
+
+Usage:
+    python {{name}}.py command [options]
+    
+Examples:
+    python {{name}}.py --help
+    {{examples}}
+"""
+
+import argparse
+from pathlib import Path
+from typing import Optional
+import yaml
+
+# Configuration
+DEFAULT_VALUE = "{{default_value}}"  # {{default_explanation}}
+VALID_OPTIONS = {{valid_options}}    # {{options_explanation}}
+
+def main():
+    """Main entry point — CLI structure only, no implementation.
+    
+    The entire command tree is visible here. Implementation is below.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__.split('\n')[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--version", action="version", version="0.1.0")
+    
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    
+{{#commands}}
+    # {{command_name}} command
+    {{command_name}}_parser = subparsers.add_parser(
+        "{{command_name}}", 
+        help="{{command_description}}"
+    )
+    {{command_name}}_parser.add_argument(
+        "{{argument_name}}", 
+        help="{{argument_description}}"
+    )
+    {{command_name}}_parser.add_argument(
+        "--verbose", "-v", 
+        action="store_true",
+        help="Show detailed output"
+    )
+{{/commands}}
+    
+    args = parser.parse_args()
+    _dispatch(args)
+
+# Implementation (LLM only reads past here if modifying behavior)
+
+def _dispatch(args):
+    """Route to appropriate handler based on command."""
+{{#commands}}
+    if args.command == "{{command_name}}":
+        _{{command_name}}_impl(args.{{argument_name}}, args.verbose)
+{{/commands}}
+
+{{#commands}}
+def _{{command_name}}_impl({{argument_name}}: str, verbose: bool) -> None:
+    """Internal: Execute {{command_name}} command."""
+    if verbose:
+        print(f"Running {{command_name}} with {{{argument_name}}}...")
+    
+    # TODO: Implement {{command_name}} logic
+    print(f"{{command_name}} completed.")
+
+{{/commands}}
+
+# === MAIN ===
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Structure Python so first 50 lines contain everything needed to use it
- Prefer argparse for clean structure/implementation separation
- Comments as semantic data, not decorative cruft
- SNIFF CODE command for language-agnostic review
- Contrasts with Steve Jobs' 'lickable pixels' - programming languages as UIs
- Arguments against syntax compression (Perl as cautionary tale)
- Comprehension fidelity > token count