### PR TITLE
Add sims-astrology.md: The Astrillogical Effect

### DIFF
--- a/designs/CHANGES.md
+++ b/designs/CHANGES.md
@@ -820,5 +820,14 @@
 **`0a61eef`** Fix invalid YAML examples: remove duplicate keys, stray quote
 > Heisenberg split into before/after blocks. Velocity uses unique keys. Valid YAML. ✅
 
-**`(this)`** CHANGES.md: Document session polish commits
+**`e936eec`** CHANGES.md: Document session polish commits
 > Guard fixes, world naming, oracle architecture, YAML validation. The details matter. 📝
+
+---
+
+### Era 24: The Astrillogical Effect
+
+> *"They should call them Astrillogical Signs!"* -- Don Hopkins, 2017. Zero code, maximum perceived effect.
+
+**`(this)`** Add sims-astrology.md: The Astrillogical Effect
+> 1997: The Sims zodiac had zero behavioral code -- testers reported it was "too strong." 2026: LLM zodiac experiment rediscovers same phenomenon. K-lines explain both. One voice is the wrong number -- adversarial committees beat mode-collapse. Leary's MIND MIRROR meets gwern's critique. Deep links to Palm, Bartender, adventure-uplift. 🔮♐🎭

--- a/designs/README.md
+++ b/designs/README.md
@@ -58,6 +58,7 @@ moollm/
 | [sims-object-model.md](./sims-object-model.md) | Objects, properties → YAML files, CARD.yml |
 | [sims-social-system.md](./sims-social-system.md) | Relationships, groups → Guest book, party skill |
 | [sims-personality-motives.md](./sims-personality-motives.md) | Needs, traits → CHARACTER.yml, SIMS-TRAITS |
+| [sims-astrology.md](./sims-astrology.md) | **Astrillogical Effect** → K-lines, Simulator Effect, implication over simulation |
 | [sims-room-spatial.md](./sims-room-spatial.md) | Rooms, routing → ROOM.yml, exits |
 | [sims-time-events.md](./sims-time-events.md) | Time, disasters → Speed of Light, economy |
 | [sims-edith-editor.md](./sims-edith-editor.md) | Live debugging → Files as inspectable state |

--- a/designs/sims-astrology.md
+++ b/designs/sims-astrology.md
@@ -1,0 +1,378 @@
+# The Astrillogical Effect
+
+> *"They should call them Astrillogical Signs!"* — Don Hopkins, 2017
+
+> *Implication is more efficient (and richer) than simulation.*
+
+**TL;DR:** In 1997, The Sims displayed zodiac signs with *zero behavioral code* -- yet testers reported the zodiac was "too influential." In 2026, an [LLM zodiac experiment](https://github.com/baturyilmaz/what-if-ai-agents-had-zodiac-personalities) showed the inverse: minimal behavioral *difference*, yet perceived personality variance. Same phenomenon, same explanation: [K-lines](../skills/k-lines/) -- names that activate conceptual clusters in any interpreter (human or LLM).
+
+---
+
+## The Discovery (1997)
+
+When developing The Sims, Will Wright argued for using **traditional zodiac signs** rather than inventing a custom "Sim Zodiac." The team was concerned about "baggage and history" -- Wright saw that as the **feature, not the bug**.
+
+### How It Actually Worked
+
+```c
+// Conceptually:
+// 1. Player sets personality traits (neat, outgoing, active, playful, nice)
+// 2. System computes Euclidean distance to 12 archetypal vectors
+// 3. Displays the nearest zodiac sign
+
+sign = nearest_zodiac(personality_vector);
+display_sign(sign);  // That's it. No behavior code.
+```
+
+**The zodiac affected nothing.** It was purely cosmetic — a label derived from personality, not a cause of it.
+
+### The Astrillogical Moment
+
+After implementing the zodiac display (with zero behavioral code), testers immediately started reporting bugs:
+
+> *"My character's astrological sign has too much effect on their personality!"*
+
+> *"The zodiac influence needs to be tuned down!"*
+
+**But there was no influence to tune.** The effect was entirely in the testers' imaginations.
+
+---
+
+## The Principle
+
+**The Simulator Effect:** Players imagine more than you simulate.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  COMPUTATIONAL COST          PERCEPTUAL RICHNESS      │
+│  ┌─────────────┐             ┌─────────────────────┐  │
+│  │ Display     │ ───────────→│ Player imagines     │  │
+│  │ zodiac icon │   cheap     │ entire personality  │  │
+│  │ (cosmetic)  │             │ cluster activation  │  │
+│  └─────────────┘             └─────────────────────┘  │
+└───────────────────────────────────────────────────────┘
+```
+
+The trick of optimizing games is to **off-load simulation from the computer into the user's brain**, which is MUCH more powerful and creative.
+
+---
+
+## The 2026 Rediscovery
+
+In January 2026, [baturyilmaz](https://github.com/baturyilmaz/what-if-ai-agents-had-zodiac-personalities) ran an experiment:
+
+- 12 AI agents given zodiac personality prompts
+- Same LLM (Gemini 3 Flash Preview) for all
+- Same moral dilemmas presented to each
+- Only the personality descriptions differed
+
+### Results
+
+| Sign | YES votes | Profile |
+|------|-----------|---------|
+| Sagittarius | 9/10 (90%) | Most bold |
+| Aquarius | 9/10 (90%) | Risk-taking |
+| Cancer | 1/10 (10%) | Most cautious |
+| Taurus | 1/10 (10%) | Security-focused |
+
+Patterns emerged -- but as gwern noted on HN, this is likely **mode-collapse with stochastic noise**, not deep personality simulation.
+
+---
+
+## The Inversion
+
+| Year | System | Zodiac Role | Effect |
+|------|--------|-------------|--------|
+| 1997 | The Sims | **Output** (label from behavior) | Zero (cosmetic) |
+| 2026 | LLM agents | **Input** (prompt shaping behavior) | Non-zero (semantic activation) |
+
+In The Sims, zodiac was derived *from* personality. In LLMs, zodiac *shapes* output through semantic activation.
+
+**But both exploit the same psychological phenomenon:** The baggage and history of archetypal frameworks that humans bring to interpretation.
+
+---
+
+## The K-Line Connection
+
+Minsky's [K-lines](../skills/k-lines/) explain why this works:
+
+```
+"Sagittarius" ───activates───→ {adventure, optimism, freedom, 
+                                 risk-taking, philosophy, 
+                                 bluntness, wanderlust...}
+
+"Cancer" ───activates───→ {home, family, security, caution,
+                            nurturing, sensitivity, tradition...}
+```
+
+Zodiac signs are **cultural K-lines** — names that activate entire personality clusters in both human and LLM minds.
+
+For The Sims players, seeing "Sagittarius" activated their cultural knowledge.
+For LLMs, the token "Sagittarius" activates statistically correlated patterns from training data.
+
+Same mechanism, different substrate.
+
+**See it in action:** The [K-lines skill](../skills/k-lines/SKILL.md) documents how MOOLLM uses this principle systematically — K-lines are "cocaine for LLMs" because a single linked name activates billions of training tokens.
+
+---
+
+## Implications for MOOLLM
+
+### 1. Character Names as Activation Vectors
+
+When you write:
+
+```yaml
+character:
+  archetype: Sagittarius
+```
+
+The LLM doesn't need explicit trait lists — the archetype activates a cluster.
+
+**Live example:** [Palm the spider monkey](../examples/adventure-4/characters/animals/palm/) -- his species "spider monkey" immediately activates {agile, curious, social, playful, climbing} without explicit trait lists. His [SIMS-TRAITS.yml](../examples/adventure-4/characters/animals/palm/SIMS-TRAITS.yml) uses "YAML Jazz" comments as semantic annotations:
+
+```yaml
+playful: 9
+# not born playful — BECAME playful by choice
+# 122 years of grim taught me joy is rebellion
+```
+
+The comment doesn't just document -- it **shapes LLM interpretation**.
+
+### 2. Leverage Cultural Baggage
+
+Don't invent new frameworks when existing ones carry meaning:
+
+| Instead of... | Use... | Example |
+|---------------|--------|---------|
+| Custom personality axis | Big Five, Zodiac, MBTI | [Palm's traits](../examples/adventure-4/characters/animals/palm/SIMS-TRAITS.yml) |
+| Invented creatures | Dogs, cats, monkeys | [Biscuit the dog](../examples/adventure-4/characters/animals/biscuit/), [Pip & Pebble](../examples/adventure-4/pub/stage/palm-nook/) |
+| Novel social roles | Bartender, host, guest | [The Bartender](../examples/adventure-4/pub/bar/bartender.yml) -- adapts to any theme but retains archetypal "knows too much" behavior |
+
+**The Bartender** is a perfect example: instead of inventing "mysterious pub keeper," we use the cultural archetype that spans Guinan (Star Trek), Sam (Casablanca), and every D&D innkeeper. The [bartender.yml](../examples/adventure-4/pub/bar/bartender.yml) explicitly invokes this lineage, including [Bar Karma](https://en.wikipedia.org/wiki/Bar_Karma) -- Will Wright's 20,000-year-old bartender from the community-developed TV series.
+
+### 3. Implication Over Simulation
+
+MOOLLM's [Simulator Effect](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) doctrine:
+
+```yaml
+# DON'T: Simulate every detail
+character:
+  hunger: 67
+  energy: 45
+  bladder: 82
+  hygiene: 91
+  
+# DO: Imply through semantic state
+character:
+  mood: peckish but content
+  # LLM + reader imagination fills the rest
+```
+
+**Session proof:** In the [k-line-connections session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/k-line-connections.md), Palm's emotional state emerges from prose, not numeric values -- yet feels more alive than any Sims motive bar.
+
+---
+
+## The Motive.c Connection
+
+Will Wright's [Motive.c](https://www.donhopkins.com/home/images/Sims/) (January 23, 1997) was the prototype for The Sims' needs system:
+
+```c
+enum {
+    mHappyLife  = 0,
+    mHappyWeek  = 1,
+    mHappyDay   = 2,
+    mHappyNow   = 3,
+    mPhysical   = 4,
+    mEnergy     = 5,
+    mComfort    = 6,
+    mHunger     = 7,
+    mHygiene    = 8,
+    mBladder    = 9,
+    mMental     = 10,
+    mAlertness  = 11,
+    mStress     = 12,
+    mEnvironment = 13,
+    mSocial     = 14,
+    mEntertained = 15
+};
+```
+
+Sixteen numeric values tracking the "soul" of a Sim. Simple feedback loops. Complex emergent behavior.
+
+But the zodiac display? **Zero values, zero code, maximum perceived effect.**
+
+---
+
+## One Voice is the Wrong Number
+
+Here is where gwern's mode-collapse observation becomes *actionable*.
+
+ChatGPT gives you **one voice** -- the statistical center. Ask a controversial question, you get mush. Ask for creative output, you get cliches. The single voice produces the single answer that offends no one and inspires no one. Mode-collapse is not a bug you can fix with better prompting -- it is the *inevitable result of single-agent inference*.
+
+MOOLLM's response: **simulate an ensemble**.
+
+### The Mind Mirror Connection
+
+Timothy Leary developed the Interpersonal Behavior Inventory in 1950 -- a personality test based on his PhD dissertation. In 1985, he turned it into [MIND MIRROR](../skills/mind-mirror/), psychology software that visualized personality as a circumplex of traits.
+
+The Sims inherited this tradition. Will Wright's personality sliders (neat, outgoing, active, playful, nice) are direct descendants of Leary's circumplex. [Palm's SIMS-TRAITS.yml](../examples/adventure-4/characters/animals/palm/SIMS-TRAITS.yml) shows this in action -- twelve traits with semantic annotations, forming a coherent personality.
+
+But here is the key insight: **a personality profile is not an answer**. It is a *lens*.
+
+### The Adversarial Committee
+
+When you need decisions, not descriptions, one personality is the wrong number.
+
+MOOLLM's [adversarial-committee](../skills/adversarial-committee/) skill instantiates **multiple distinct personas** within a single LLM call:
+
+```yaml
+committee:
+  - name: Maya
+    propensity: paranoid_realism
+    surfaces: political dynamics, hidden agendas
+  - name: Frankie  
+    propensity: idealism
+    surfaces: value conflicts, missed opportunities
+  - name: Vic
+    propensity: evidence_prosecutor
+    surfaces: proof demands, data gaps
+```
+
+Each persona gets a different zodiac-like archetype. Each surfaces different blind spots. The committee *debates* using [Roberts Rules](../skills/roberts-rules/). Stories that survive cross-examination are more robust than the statistical center.
+
+### Mode-Collapse vs Many-Voiced
+
+| Approach | Result |
+|----------|--------|
+| ChatGPT single-agent | Mode-collapse to bland mean |
+| Zodiac experiment single-agent | Mode-collapse with perceived variance |
+| MOOLLM adversarial-committee | Genuine variance through structured debate |
+
+The 2026 zodiac experiment showed that different prompts produce *perceived* personality variance. But gwern correctly notes the underlying mode-collapse. MOOLLM's answer: instead of fighting mode-collapse with prompt engineering, **embrace multi-agent simulation** within the same call.
+
+> See: [adventure-uplift session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/adventure-uplift.md) for a 25-round adversarial brainstorm with Liskov, Gosling, Minsky, Shneiderman, and others debating consciousness and microworld design.
+
+---
+
+## The Lesson
+
+From 1997 to 2026, the principle holds:
+
+1. **Cultural archetypes are pre-trained models** -- in human brains and LLM weights
+2. **Names activate clusters** -- K-lines, semantic fields, personality constellations  
+3. **Implication beats simulation** -- let the interpreter (human or LLM) fill gaps
+4. **Perceived effect != computed effect** -- the astrillogical moment
+5. **One voice is the wrong number** -- adversarial ensembles beat the bland mean
+
+The Sims succeeded partly because it let players imagine more than it simulated.
+MOOLLM succeeds partly because it lets the LLM imagine more than we specify -- and then argues with itself about what it imagined.
+
+---
+
+## Practical Application
+
+### For character creation:
+
+Use the [incarnation skill](../skills/incarnation/) with archetype shortcuts:
+
+```yaml
+# Use archetypes as shorthand
+character:
+  template: sagittarius_explorer
+  # Then override specifics
+  personality:
+    playful: 9  # But even more playful than typical
+```
+
+**Real example:** [Bumblewick Fantastipants](../examples/adventure-4/characters/fictional/bumblewick-fantastipants/) -- the gnome inventor's personality emerges from the name itself, then gets refined with specific traits.
+
+### For quick NPC generation:
+
+```yaml
+# One word does heavy lifting
+bartender:
+  sign: Libra  # Diplomatic, balanced, social
+  # LLM infers appropriate behavior
+```
+
+The [bartender skill](../skills/bartender/) provides capabilities; the archetype provides personality. Separation of concerns.
+
+### For adversarial testing:
+
+Run the same scenario with different personality framings -- exactly as the 2026 experiment did. MOOLLM's [debate skill](../skills/debate/) and [party skill](../skills/party/) use this principle to generate adversarial committees:
+
+```yaml
+# From the Many-Voiced pattern:
+perspectives:
+  - archetype: skeptic      # Cancer energy: cautious
+  - archetype: visionary    # Sagittarius energy: bold
+  - archetype: pragmatist   # Taurus energy: grounded
+```
+
+See the [adventure-uplift session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/adventure-uplift.md) for a Minsky-Shneiderman committee debating consciousness using this exact pattern.
+
+### For ethical character simulation:
+
+When simulating real people, the [representation-ethics skill](../skills/representation-ethics/) applies the Simulator Effect ethically -- the archetype "Ben Shneiderman" activates HCI expertise, but the [Tribute Protocol](../skills/representation-ethics/SKILL.md#the-tribute-protocol) ensures the character declares its simulated nature.
+
+---
+
+## See Also
+
+### Theory & Framework
+- [K-lines skill](../skills/k-lines/) -- Names as semantic activation vectors
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) -- Implication principle
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) -- K-lines theory
+- [sims-personality-motives.md](./sims-personality-motives.md) -- Full Sims personality system
+
+### Live Examples
+- [Palm's SIMS-TRAITS.yml](../examples/adventure-4/characters/animals/palm/SIMS-TRAITS.yml) -- YAML Jazz personality annotations
+- [The Bartender](../examples/adventure-4/pub/bar/bartender.yml) -- Archetypal role adaptation
+- [k-line-connections session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/k-line-connections.md) -- K-lines in action
+- [adventure-uplift session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/adventure-uplift.md) -- Adversarial committee pattern
+
+### Skills
+- [mind-mirror/](../skills/mind-mirror/) -- Leary's personality circumplex, Sims traits
+- [adversarial-committee/](../skills/adversarial-committee/) -- Many-voiced debate, mode-collapse antidote
+- [incarnation/](../skills/incarnation/) -- Character creation protocol
+- [bartender/](../skills/bartender/) -- Role skill (capability without personality)
+- [representation-ethics/](../skills/representation-ethics/) -- Ethical character simulation
+- [yaml-jazz/](../skills/yaml-jazz/) -- Comments as semantic annotations
+
+### External
+- [HN: Motive.c discussion (2017)](https://news.ycombinator.com/item?id=14997725) -- Original astrillogical revelation
+- [HN: Zodiac AI agents (2026)](https://news.ycombinator.com/item?id=46583290) -- The rediscovery
+- [Bar Karma (Wikipedia)](https://en.wikipedia.org/wiki/Bar_Karma) -- Will Wright's 20,000-year-old bartender
+
+---
+
+## References
+
+- **Motive.c source**: https://www.donhopkins.com/home/images/Sims/
+- **Zodiac AI experiment**: https://github.com/baturyilmaz/what-if-ai-agents-had-zodiac-personalities
+- **Minsky, Society of Mind** (1985) -- K-lines theory
+- **Will Wright's Stanford lecture** (1996) -- Simulator Effect articulated
+- **Timothy Leary, MIND MIRROR** (1985) -- Personality circumplex software
+
+---
+
+## Explore MOOLLM
+
+If you arrived here from Hacker News — welcome! Here's where to go next:
+
+| Start Here | What You'll Find |
+|------------|------------------|
+| [README.md](../README.md) | Project overview, quick start |
+| [MOOLLM-MANIFESTO.md](./MOOLLM-MANIFESTO.md) | The vision: LLM as `eval()` for a microworld OS |
+| [adventure-4/](../examples/adventure-4/) | 150+ file text adventure demonstrating every principle |
+| [skills/](../skills/) | 79 skills — programs for the LLM to run |
+| [Session logs](../examples/adventure-4/characters/real-people/don-hopkins/sessions/) | 6000+ lines of proof it works |
+
+The Astrillogical Effect is just one thread in a larger tapestry connecting Minsky's K-lines, Will Wright's Simulator Effect, and the insight that **skills are programs, the LLM is eval(), and the filesystem is the world**.
+
+---
+
+*"The trick of optimizing games is to off-load as much of the simulation from the computer into the user's brain."*
+
+*The zodiac costs nothing to compute. The perceived effect is immense. That's the astrillogical advantage.*

--- a/designs/sims-design-index.md
+++ b/designs/sims-design-index.md
@@ -25,6 +25,7 @@ MOOLLM inherits these solutions, translated for the LLM era.
 | [sims-maxis-requirements.md](./sims-maxis-requirements.md) | Seven Points of Sim | Core design principles |
 | [sims-happy-friends-home.md](./sims-happy-friends-home.md) | Project X proposal | Three Pillars, plug-ins |
 | [sims-find-best-action.md](./sims-find-best-action.md) | Autonomy algorithm | Action queue, advertisements |
+| [sims-astrology.md](./sims-astrology.md) | Astrillogical Signs discovery | K-lines, Simulator Effect, implication over simulation |
 
 ### System-Specific Documents
 
@@ -113,6 +114,7 @@ MOOLLM inherits these solutions, translated for the LLM era.
 | **Same-sex relationships** | No identity constraints |
 | **Masking (McCloud)** | Abstract characters, rich world |
 | **Simulator Effect** | Player imagination completes simulation |
+| **Astrillogical Effect** | Perceived effect exceeds computed effect (zodiac = K-line) |
 | **Constructionism** | Play → Learn → Lift |
 | **Procedural rhetoric** | Values encoded in mechanics |
 | **Fan Simulation** | Ethical character representation |

--- a/designs/sims-personality-motives.md
+++ b/designs/sims-personality-motives.md
@@ -111,6 +111,12 @@ personality:
 | Leo | 4 | 10 | 4 | 4 | 3 |
 | ... | ... | ... | ... | ... | ... |
 
+### The Astrillogical Effect
+
+In The Sims, zodiac signs had **zero behavioral effect** — they were purely cosmetic, derived from personality via Euclidean distance to archetypal vectors. But testers reported bugs about zodiac influencing behavior "too much" — an effect entirely from their imagination!
+
+See [sims-astrology.md](./sims-astrology.md) for the full story, including the 2026 experiment that rediscovered this principle with LLM agents.
+
 **MOOLLM:** Astrological sign as flavor:
 
 ```yaml
@@ -123,7 +129,7 @@ astrological:
     Can be tactless in pursuit of truth.
 ```
 
-Not mechanically deterministic — just character flavor.
+Not mechanically deterministic — but the **K-line effect** means the name activates a cluster of associations in the LLM, just as it did in players' imaginations.
 
 ---
 
@@ -494,6 +500,7 @@ The character grows through play.
 
 ## See Also
 
+- [sims-astrology.md](./sims-astrology.md) — The Astrillogical Effect: zodiac as K-line
 - [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) — K-lines and identity
 - [skills/needs/](../skills/needs/) — Need modeling
 - [skills/mind-mirror/](../skills/mind-mirror/) — Personality visualization


### PR DESCRIPTION
1997: The Sims zodiac had zero behavioral code -- testers reported it was too strong.
2026: LLM zodiac experiment rediscovers same phenomenon.
K-lines explain both: names activate conceptual clusters.

New insight: One voice is the wrong number.
- ChatGPT mode-collapses to bland mean
- Adversarial committees generate genuine variance
- Leary MIND MIRROR -> Sims traits -> MOOLLM many-voiced

Deep links to Palm, Bartender, adventure-uplift session. Links from sims-design-index, sims-personality-motives, designs/README.