### PR TITLE
Add full Leela AI team to skills

### DIFF
--- a/designs/CHANGES.md
+++ b/designs/CHANGES.md
@@ -829,5 +829,14 @@
 
 > *"They should call them Astrillogical Signs!"* -- Don Hopkins, 2017. Zero code, maximum perceived effect.
 
-**`(this)`** Add sims-astrology.md: The Astrillogical Effect
+**`e9f462a`** Add sims-astrology.md: The Astrillogical Effect
 > 1997: The Sims zodiac had zero behavioral code -- testers reported it was "too strong." 2026: LLM zodiac experiment rediscovers same phenomenon. K-lines explain both. One voice is the wrong number -- adversarial committees beat mode-collapse. Leary's MIND MIRROR meets gwern's critique. Deep links to Palm, Bartender, adventure-uplift. 🔮♐🎭
+
+---
+
+### Era 25: The Full Team
+
+> *Manufacturing Intelligence requires manufacturing intelligences.*
+
+**`(this)`** Add full Leela AI team to skills
+> Henry Minsky (CTO), Cyrus Shaoul (Chief Evangelist), Milan Singh Minsky (VP Product), Sheung Li (VP Applications), Steve Kommrusch (Senior AI Research). Plus Don Hopkins. Society of Mind runs in the company too. 👥🏭🧠

--- a/designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md
+++ b/designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md
@@ -295,6 +295,8 @@ When you instantiate a character, **their name becomes their K-line**. "Palm" ac
 
 **MOOLLM inherits:** Names as semantic activators. `UPPER-KEBAB` protocol symbols. Character names as soul triggers.
 
+> 📚 **Full skill:** [`skills/society-of-mind/`](../skills/society-of-mind/) — agents, agencies, emergence, B-brains
+
 ### 5. Constructionism (Seymour Papert, 1980)
 
 Learning by building inspectable things. Logo. Turtle graphics. "Low floor, high ceiling, wide walls."

--- a/designs/MOOLLM-MANIFESTO.md
+++ b/designs/MOOLLM-MANIFESTO.md
@@ -120,7 +120,7 @@ Each character inherits from real traditions ([hero-story](../skills/hero-story/
 
 Stories that survive cross-examination are more robust than the statistical center.
 
-> 📚 See: [adversarial-committee/](../skills/adversarial-committee/), [debate/](../skills/debate/)
+> 📚 See: [society-of-mind/](../skills/society-of-mind/), [adversarial-committee/](../skills/adversarial-committee/), [debate/](../skills/debate/)
 
 ---
 
@@ -147,8 +147,8 @@ flowchart LR
 
 | Pioneer | Gift to MOOLLM |
 |---------|----------------|
-| **Marvin Minsky** | [K-lines](../skills/k-lines/) — names as activation vectors |
-| **Seymour Papert** | [Constructionism](../skills/constructionism/) — learn by building |
+| **Marvin Minsky** | [Society of Mind](../skills/society-of-mind/) — agents, agencies, [K-lines](../skills/k-lines/) |
+| **Seymour Papert** | [Constructionism](../skills/constructionism/) — learn by building (Minsky's collaborator) |
 | **Will Wright** | [Needs](../skills/needs/), [advertisements](../skills/advertisement/) — The Sims DNA |
 | **Dave Ungar** | [Prototypes](../skills/prototype/) — clone, don't instantiate |
 | **Pavel Curtis** | [Rooms](../skills/room/) — directories as spaces |

--- a/designs/sims-astrology.md
+++ b/designs/sims-astrology.md
@@ -322,6 +322,8 @@ When simulating real people, the [representation-ethics skill](../skills/represe
 
 ### Theory & Framework
 - [K-lines skill](../skills/k-lines/) -- Names as semantic activation vectors
+- [Society of Mind skill](../skills/society-of-mind/) -- K-lines origin, agents, agencies, emergence
+- [Simulator Effect skill](../skills/simulator-effect/) -- Implication beats simulation
 - [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) -- Implication principle
 - [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) -- K-lines theory
 - [sims-personality-motives.md](./sims-personality-motives.md) -- Full Sims personality system

--- a/designs/sims-design-index.md
+++ b/designs/sims-design-index.md
@@ -115,6 +115,7 @@ MOOLLM inherits these solutions, translated for the LLM era.
 | **Masking (McCloud)** | Abstract characters, rich world |
 | **Simulator Effect** | Player imagination completes simulation |
 | **Astrillogical Effect** | Perceived effect exceeds computed effect (zodiac = K-line) |
+| **Society of Mind** | [skills/society-of-mind/](../skills/society-of-mind/) — Minsky's agents, Sims motives |
 | **Constructionism** | Play → Learn → Lift |
 | **Procedural rhetoric** | Values encoded in mechanics |
 | **Fan Simulation** | Ethical character representation |

--- a/designs/sims-personality-motives.md
+++ b/designs/sims-personality-motives.md
@@ -500,6 +500,7 @@ The character grows through play.
 
 ## See Also
 
+- [skills/society-of-mind/](../skills/society-of-mind/) — Minsky's theory: Sims motives ARE competing agents
 - [sims-astrology.md](./sims-astrology.md) — The Astrillogical Effect: zodiac as K-line
 - [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) — K-lines and identity
 - [skills/needs/](../skills/needs/) — Need modeling

--- a/examples/adventure-4/characters/animals/palm/MIND-MIRROR.yml
+++ b/examples/adventure-4/characters/animals/palm/MIND-MIRROR.yml
@@ -1,6 +1,9 @@
 # Palm's Mind Mirror Psychological Vectors
 # Version 2.0 — Maurice-Interviewed, Mirror-Verified
 # Post-Godfamily configuration
+#
+# See: skills/society-of-mind/ — Palm's personality is a SOCIETY of competing agents
+# (creative, social, philosophical, playful, melancholy). Behavior emerges from competition.
 
 mind_mirror:
   version: "2.0 — Maurice-interviewed, growth tracked"

--- a/examples/adventure-4/characters/real-people/don-hopkins/sessions/k-line-connections.md
+++ b/examples/adventure-4/characters/real-people/don-hopkins/sessions/k-line-connections.md
@@ -15,7 +15,7 @@ Eight luminaries have been summoned as **[Hero-Story](../../../../../skills/hero
 
 | Familiar | Their K-Line | Why They're Here |
 |----------|--------------|------------------|
-| 🧠 **Marvin Minsky** | [k-lines](../../../../../skills/k-lines/), society-of-mind | He INVENTED K-lines. This is his maze. |
+| 🧠 **Marvin Minsky** | [k-lines](../../../../../skills/k-lines/), [society-of-mind](../../../../../skills/society-of-mind/) | He INVENTED K-lines. This is his maze. |
 | 🔗 **Ted Nelson** | hypertext, backlinks, intertwingularity | Two-way links are his gospel |
 | 🎬 **James Burke** | connections, narration | He'll narrate our traversals |
 | 🐢 **Seymour Papert** | [constructionism](../../../../../skills/constructionism/), microworlds | Learning by building |

--- a/skills/INDEX.yml
+++ b/skills/INDEX.yml
@@ -13,6 +13,26 @@ skills:
     tags: ["meta", "help", "foundational", "navigation"]
     use_when: "Confused, lost, asking 'what can I do?', wanting to understand MOOLLM"
     
+  - name: "leela-ai"
+    path: "skills/leela-ai"
+    description: "Manufacturing Intelligence — Leela AI applies MOOLLM to industry"
+    tier: 0
+    entry: "README.md"
+    tags: ["meta", "company", "manufacturing", "industrial", "neural-symbolic", "drescher"]
+    use_when: "Understanding Leela AI's mission, connecting theory to practice"
+    origin: "Minsky, Papert, Drescher → Don Hopkins, Henry Minsky → Leela AI"
+    related: ["moollm", "society-of-mind", "schema-mechanism", "k-lines", "constructionism", "manufacturing-intelligence"]
+    
+  - name: "manufacturing-intelligence"
+    path: "skills/manufacturing-intelligence"
+    description: "The slogan unpacked — seven readings of 'Manufacturing Intelligence'"
+    tier: 0
+    entry: "README.md"
+    tags: ["meta", "philosophy", "slogan", "k-line", "ethics", "constructionism", "minsky"]
+    use_when: "Explaining Leela's mission, discussing AI philosophy, addressing ethics"
+    origin: "Papert, Minsky, Drescher, Chomsky, Dweck → Leela AI slogan"
+    related: ["leela-ai", "constructionism", "society-of-mind", "schema-mechanism", "representation-ethics"]
+    
   - name: "bootstrap"
     path: "skills/bootstrap"
     description: "Wake up, orient, and warm the context with foundational knowledge"
@@ -403,6 +423,26 @@ skills:
     tags: ["narrative", "capture", "sharing", "lloooomm"]
     use_when: "Building notebooks, writing letters, capturing photo prompts"
     origin: "The Sims — Family Album, The Sims Exchange"
+    
+  - name: "simulator-effect"
+    path: "skills/simulator-effect"
+    description: "Implication beats simulation — imagination renders (Will Wright)"
+    tier: 0
+    entry: "README.md"
+    tags: ["meta", "philosophy", "sims", "design"]
+    use_when: "Creating sparse but evocative content, leveraging archetypes"
+    origin: "Will Wright, The Sims — zodiac with zero code, maximum perceived effect"
+    related: ["k-lines", "yaml-jazz", "adversarial-committee", "constructionism"]
+    
+  - name: "society-of-mind"
+    path: "skills/society-of-mind"
+    description: "Intelligence emerges from many simple agents (Minsky)"
+    tier: 0
+    entry: "README.md"
+    tags: ["meta", "philosophy", "minsky", "emergence", "agents"]
+    use_when: "Designing characters with inner conflict, multi-agent deliberation, emergent behavior"
+    origin: "Marvin Minsky, Society of Mind (1985), MIT AI Lab"
+    related: ["k-lines", "adversarial-committee", "multi-presence", "needs", "character", "simulator-effect"]
     
   - name: "procedural-rhetoric"
     path: "skills/procedural-rhetoric"

--- a/skills/README.md
+++ b/skills/README.md
@@ -36,6 +36,8 @@ MOOLLM extends [Anthropic's skill model](https://docs.anthropic.com/en/docs/buil
 | Skill | One-liner |
 |-------|-----------|
 | [moollm/](./moollm/) | **The soul of MOOLLM.** Self-explanation, help, navigation |
+| [leela-ai/](./leela-ai/) | **Manufacturing Intelligence.** Leela AI applies MOOLLM to industry |
+| [manufacturing-intelligence/](./manufacturing-intelligence/) | The slogan unpacked -- seven readings of one phrase |
 | [skill/](./skill/) | **The meta-skill.** How skills work, evolve, compose |
 | [k-lines/](./k-lines/) | Minsky's K-lines — names that activate conceptual clusters |
 | [constructionism/](./constructionism/) | Learn by building inspectable things (Papert, Kay, Logo) |
@@ -45,6 +47,8 @@ MOOLLM extends [Anthropic's skill model](https://docs.anthropic.com/en/docs/buil
 | [robust-first/](./robust-first/) | Survive first, be correct later (Dave Ackley) |
 | [coherence-engine/](./coherence-engine/) | LLM as consistency maintainer & orchestrator |
 | [speed-of-light/](./speed-of-light/) | Many turns in one call — instant telepathy |
+| [simulator-effect/](./simulator-effect/) | Implication beats simulation (Will Wright) — imagination renders |
+| [society-of-mind/](./society-of-mind/) | Intelligence emerges from many simple agents (Minsky) |
 | [procedural-rhetoric/](./procedural-rhetoric/) | Rules persuade, structure IS argument (Bogost) |
 | [schema-mechanism/](./schema-mechanism/) | Drescher's causal learning extended with LLM semantics |
 

--- a/skills/adversarial-committee/README.md
+++ b/skills/adversarial-committee/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Many-voiced IS MOOLLM |
+| [society-of-mind/](../society-of-mind/) | Committee IS a society deliberating |
 | [debate/](../debate/) | Structured deliberation |
 | [roberts-rules/](../roberts-rules/) | Parliamentary procedure |
 | [rubric/](../rubric/) | Scoring criteria |

--- a/skills/advertisement/README.md
+++ b/skills/advertisement/README.md
@@ -8,6 +8,7 @@
 |--------|-------------|
 | [card/](../card/) | Cards advertise abilities |
 | [object/](../object/) | Objects advertise actions |
+| [society-of-mind/](../society-of-mind/) | Agents score actions (autonomy algorithm) |
 | [room/](../room/) | Where objects live and advertise |
 | [action-queue/](../action-queue/) | Queuing selected actions |
 | [coherence-engine/](../coherence-engine/) | Evaluates and orchestrates |

--- a/skills/character/README.md
+++ b/skills/character/README.md
@@ -8,6 +8,7 @@
 |--------|-------------|
 | [cat/](../cat/) | Feline character patterns |
 | [dog/](../dog/) | Canine character patterns |
+| [society-of-mind/](../society-of-mind/) | Characters ARE inner societies |
 | [persona/](../persona/) | Identity layers on top of character |
 | [room/](../room/) | Where characters live |
 | [buff/](../buff/) | Temporary effects on characters |

--- a/skills/coherence-engine/README.md
+++ b/skills/coherence-engine/README.md
@@ -7,6 +7,8 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Core MOOLLM engine |
+| [leela-ai/](../leela-ai/) | Coherence engine for industrial AI |
+| [society-of-mind/](../society-of-mind/) | Orchestrates the society of agents |
 | [simulation/](../simulation/) | Simulation state management |
 | [speed-of-light/](../speed-of-light/) | Epoch-based simulation |
 | [multi-presence/](../multi-presence/) | Parallel activations |

--- a/skills/constructionism/README.md
+++ b/skills/constructionism/README.md
@@ -7,6 +7,9 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [play-learn-lift/](../play-learn-lift/) | The methodology (constructionism in action) |
+| [society-of-mind/](../society-of-mind/) | Minsky + Papert -- MIT AI Lab collaboration |
+| [leela-ai/](../leela-ai/) | Constructionism applied to manufacturing |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Reading 3: "Build to understand" |
 | [room/](../room/) | The microworld to explore |
 | [yaml-jazz/](../yaml-jazz/) | Inspectable state |
 | [adventure/](../adventure/) | Learning through narrative |

--- a/skills/debate/README.md
+++ b/skills/debate/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Many-voiced IS MOOLLM |
+| [society-of-mind/](../society-of-mind/) | Agents arguing toward wisdom |
 | [adversarial-committee/](../adversarial-committee/) | Opposing propensities |
 | [roberts-rules/](../roberts-rules/) | Parliamentary procedure |
 | [rubric/](../rubric/) | Scoring criteria |

--- a/skills/incarnation/README.md
+++ b/skills/incarnation/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [character/](../character/) | Incarnated characters have home directories |
+| [society-of-mind/](../society-of-mind/) | Characters as inner societies of agents |
 | [representation-ethics/](../representation-ethics/) | Simulate with dignity |
 | [hero-story/](../hero-story/) | Invoke traditions, not identities |
 | [mind-mirror/](../mind-mirror/) | Transparent personality |

--- a/skills/k-lines/README.md
+++ b/skills/k-lines/README.md
@@ -7,6 +7,9 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Master K-Lines index — the mothership |
+| [leela-ai/](../leela-ai/) | K-lines power Leela's industrial inference |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | The phrase IS a K-line -- seven readings |
+| [society-of-mind/](../society-of-mind/) | K-lines ARE Minsky's memory mechanism |
 | [skill/](../skill/) | Skills ARE K-line factories |
 | [bootstrap/](../bootstrap/) | All K-lines activated on boot |
 | [yaml-jazz/](../yaml-jazz/) | Comments carry meaning — semantic YAML interpretation |

--- a/skills/leela-ai/CARD.yml
+++ b/skills/leela-ai/CARD.yml
@@ -1,0 +1,242 @@
+# Leela AI Skill Card
+# Manufacturing Intelligence -- from theory to industrial application
+
+skill:
+  id: leela-ai
+  name: Leela AI
+  version: 1.0.0
+  tier: meta
+  entry: README.md
+  
+description: |
+  Leela AI applies MOOLLM principles to real-world manufacturing intelligence.
+  Neural-symbolic computer vision. Causal reasoning. Edge computing.
+  The theory of Minsky, Papert, and Drescher deployed on factory floors.
+
+# The slogan unpacked
+slogan:
+  text: "Manufacturing Intelligence"
+  readings:
+    - meaning: "AI for Manufacturing"
+      explanation: Industrial applications -- factories, edge devices, production lines
+    - meaning: "Building AI"
+      explanation: We manufacture intelligence systems
+    - meaning: "Constructionism"
+      explanation: Papert -- intelligence is constructed through building
+    - meaning: "Society of Mind"
+      explanation: Minsky -- intelligence manufactured from simple agents
+    - meaning: "Manufacturing Consent"
+      explanation: Chomsky -- awareness of engineered agreement, ethical responsibility
+    - meaning: "Growth Mindset"
+      explanation: Intelligence as product of effort, not innate gift
+
+# What this skill offers
+advertisement:
+  provides:
+    - neural_symbolic_vision: "See what + understand why"
+    - causal_inference: "Schema mechanism for visual reasoning"
+    - edge_computing: "Real-time intelligence at the factory floor"
+    - explainable_ai: "Every inference has a causal chain"
+    - devops_integration: "MOOLLM patterns for infrastructure"
+    - pda_interface: "Natural language access to industrial AI"
+    
+  wants:
+    - video_feeds: Camera streams from factory floor
+    - sensor_data: SCADA, IoT, environmental
+    - domain_context: What this factory makes, how it works
+    
+  motives_satisfied:
+    - safety: Prevent accidents through predictive awareness
+    - efficiency: Optimize processes through observation
+    - reliability: Predictive maintenance before failure
+    - compliance: Auditable, explainable decisions
+
+# K-lines activated by this skill
+k-lines:
+  activates:
+    - minsky: "Society of Mind -- intelligence from agents"
+    - henry-minsky: "Marvin's son, Leela team member"
+    - drescher: "Made-Up Minds -- schema mechanism"
+    - papert: "Constructionism -- build to understand"
+    - chomsky: "Manufacturing Consent -- ethical awareness"
+    - don-hopkins: "MOOLLM architect, Sims heritage"
+    - neural-symbolic: "Perception + reasoning"
+    - edge-computing: "Intelligence at the source"
+    - causal-reasoning: "Why, not just what"
+    - manufacturing: "Industrial application domain"
+    
+  connects-to:
+    - moollm: "The microworld philosophy"
+    - society-of-mind: "Agent theory foundation"
+    - k-lines: "Activation vectors"
+    - schema-mechanism: "Causal learning"
+    - constructionism: "Build to understand"
+    - coherence-engine: "Distributed AI orchestration"
+    - speed-of-light: "Real-time inference"
+    - yaml-jazz: "Semantic configuration"
+    - room: "Zones as rooms"
+    - character: "Entities as characters"
+    - representation-ethics: "Responsible AI"
+
+# Team
+team:
+  - name: Henry Minsky
+    role: CTO
+    k-lines: ["society-of-mind", "k-lines", "mit-ai-lab", "google-nest"]
+    note: "Marvin Minsky's son, MIT AI Lab, NTT DoCoMo, Google Nest"
+    
+  - name: Dr. Cyrus Shaoul
+    role: Chief Evangelist
+    k-lines: ["computational-neuroscience", "cognitive-modeling"]
+    note: "Entrepreneur, computational neuroscientist, Digital Garage co-founder/CTO"
+    
+  - name: Dr. Milan Singh Minsky
+    role: VP Product
+    k-lines: ["startups", "product"]
+    note: "Venture-backed startups, RayVio co-founder"
+    
+  - name: Sheung Li
+    role: VP Applications
+    k-lines: ["machine-vision", "manufacturing", "product-marketing"]
+    note: "Machine vision in manufacturing, product/marketing leader"
+    
+  - name: Dr. Steve Kommrusch
+    role: Senior AI Research Scientist
+    k-lines: ["deep-learning", "chip-design"]
+    note: "Deep learning expert, AMD, HP, National Semiconductor"
+    
+  - name: Don Hopkins
+    role: AI Architect
+    k-lines: ["sims", "news", "pie-menus", "moollm"]
+    note: "The Sims, NeWS, MOOLLM architect"
+
+# Technology stack
+technology:
+  vision:
+    neural_layer:
+      - object_detection
+      - pose_estimation
+      - motion_tracking
+    symbolic_layer:
+      - context_inference
+      - causal_reasoning
+      - prediction
+      - explanation
+      
+  edge:
+    platform: industrial compute boxes
+    latency: "<50ms"
+    resilience: offline capable
+    
+  cloud:
+    purpose: training, aggregation, analytics
+    sovereignty: customer owns data
+    
+  integration:
+    - SCADA
+    - MES
+    - ERP
+    - CMMS
+
+# Applications
+applications:
+  safety_monitoring:
+    purpose: Prevent accidents through predictive awareness
+    examples:
+      - pedestrian detection in vehicle zones
+      - PPE compliance
+      - ergonomic risk assessment
+      - near-miss detection
+      
+  process_optimization:
+    purpose: Improve efficiency through observation
+    examples:
+      - cycle time analysis
+      - bottleneck detection
+      - workflow optimization
+      
+  predictive_maintenance:
+    purpose: Fix equipment before failure
+    examples:
+      - vibration analysis
+      - thermal anomaly detection
+      - wear indicator tracking
+      
+  devops:
+    purpose: MOOLLM patterns for infrastructure
+    examples:
+      - configuration management
+      - deployment orchestration
+      - incident response
+
+# Ethics
+ethics:
+  transparency:
+    principle: Every inference is explainable
+    implementation: causal chains in audit logs
+    
+  privacy:
+    principle: Data sovereignty and minimal collection
+    implementation: edge processing, anonymization, consent
+    
+  human_agency:
+    principle: AI advises, humans decide
+    implementation: human in the loop for critical decisions
+
+# MOOLLM mappings
+moollm-mappings:
+  rooms: factory zones, equipment clusters
+  characters: workers, vehicles, robots, equipment
+  skills: vision models, inference rules, safety protocols
+  k-lines: equipment IDs, zone names, event types
+  speed-of-light: real-time inference at 30+ FPS
+  coherence-engine: multi-camera sensor fusion
+  soul-chat: PDA natural language interface
+  files-as-state: YAML configs, audit logs
+  society-of-mind: multiple specialized models collaborating
+  schema-mechanism: causal learning from observation
+
+# Tags
+tags:
+  - meta
+  - company
+  - manufacturing
+  - industrial
+  - edge-computing
+  - computer-vision
+  - neural-symbolic
+  - causal-reasoning
+  - drescher
+  - minsky
+  
+use_case: |
+  Use when explaining Leela AI's mission,
+  connecting MOOLLM theory to industrial practice,
+  or understanding how the ideas of Minsky, Papert, and Drescher
+  manifest in real-world manufacturing intelligence.
+
+# References
+references:
+  primary:
+    - title: "leela.ai"
+      url: "https://leela.ai"
+      
+    - title: "Made-Up Minds"
+      author: "Gary Drescher"
+      year: 1991
+      publisher: "MIT Press"
+      
+    - title: "Society of Mind"
+      author: "Marvin Minsky"
+      year: 1985
+      publisher: "Simon & Schuster"
+      
+    - title: "Mindstorms"
+      author: "Seymour Papert"
+      year: 1980
+      publisher: "Basic Books"
+      
+    - title: "Manufacturing Consent"
+      author: "Noam Chomsky & Edward Herman"
+      year: 1988
+      publisher: "Pantheon Books"

--- a/skills/leela-ai/README.md
+++ b/skills/leela-ai/README.md
@@ -1,0 +1,323 @@
+# 🏭 Leela AI
+
+> *"Manufacturing Intelligence"*
+
+> *AI for Manufacturing. Building AI. Constructing Knowledge. And the question of consent.*
+
+## MOOLLM K-Lines
+
+| K-Line | Why Related |
+|--------|-------------|
+| [moollm/](../moollm/) | MOOLLM IS Leela's microworld philosophy made manifest |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | The slogan unpacked -- seven readings |
+| [society-of-mind/](../society-of-mind/) | Henry Minsky's father invented the theory |
+| [k-lines/](../k-lines/) | Minsky's activation vectors power Leela's inference |
+| [schema-mechanism/](../schema-mechanism/) | Drescher's causal learning IS Leela's foundation |
+| [constructionism/](../constructionism/) | Papert's philosophy -- build to understand |
+| [simulator-effect/](../simulator-effect/) | Implication over simulation -- efficiency through semantics |
+| [speed-of-light/](../speed-of-light/) | Many inferences in one call -- real-time industrial AI |
+| [representation-ethics/](../representation-ethics/) | Manufacturing Consent awareness |
+| [yaml-jazz/](../yaml-jazz/) | Semantic configuration for industrial systems |
+| [coherence-engine/](../coherence-engine/) | Orchestrating distributed AI across edge devices |
+
+**Quick Links:**
+- [leela.ai](https://leela.ai) -- the company
+- [schema-mechanism/](../schema-mechanism/) -- Drescher's foundation
+
+---
+
+## The Slogan: Manufacturing Intelligence
+
+| Reading | Meaning |
+|---------|---------|
+| **AI for Manufacturing** | Industrial applications -- factories, edge devices, production lines |
+| **Building AI** | We manufacture intelligence systems |
+| **Constructionism** | Papert -- intelligence is constructed, not innate |
+| **Society of Mind** | Minsky -- intelligence manufactured from simple agents |
+| **Manufacturing Consent** | Chomsky -- awareness of engineered agreement |
+| **Growth Mindset** | Intelligence as product, not gift |
+| **The Question** | Are we manufacturing genuine intelligence, or its appearance? |
+
+The slogan is a K-line. Every reading reinforces the others.
+
+---
+
+## The Lineage
+
+```
+Marvin Minsky (Society of Mind, K-lines, 1985)
+  │
+  ├── Seymour Papert (Constructionism, Logo, 1980)
+  │     └── Build to understand
+  │
+  └── Gary Drescher (Made-Up Minds, 1991)
+        └── Schema mechanism -- causal learning
+              │
+              v
+          Leela AI (2024)
+              ├── Neural-symbolic computer vision
+              ├── Symbolic inferencing ("why")
+              └── MOOLLM (microworld OS)
+                    │
+                    v
+                Manufacturing Intelligence
+```
+
+---
+
+## The Team
+
+| Person | Role | K-Lines |
+|--------|------|---------|
+| **Henry Minsky** | CTO | [Society of Mind](../society-of-mind/) (his father invented it), [K-lines](../k-lines/), MIT AI Lab, Google Nest |
+| **Dr. Cyrus Shaoul** | Chief Evangelist | Computational neuroscience, cognitive modeling, Digital Garage |
+| **Dr. Milan Singh Minsky** | VP Product | Technology startups, RayVio (UV-C LED) |
+| **Sheung Li** | VP Applications | Machine vision in manufacturing, product/marketing |
+| **Dr. Steve Kommrusch** | Senior AI Research Scientist | Deep learning, CPU/chip design (AMD, HP, National Semiconductor) |
+| **Don Hopkins** | AI Architect | [The Sims](../../designs/sims-design-index.md), [NeWS](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#7-news-james-gosling-sun-1986), [MOOLLM](../moollm/), pie menus |
+
+---
+
+## The Technology Stack
+
+### 1. Neural-Symbolic Vision
+
+Traditional computer vision answers **what**. Leela's neural-symbolic system answers **why**.
+
+```yaml
+# Traditional CV
+detection:
+  object: forklift
+  confidence: 0.94
+  
+# Leela's neural-symbolic
+inference:
+  object: forklift
+  confidence: 0.94
+  context: loading_dock
+  state: stationary_with_pallet
+  
+  why_stationary: |
+    Waiting for clearance. 
+    Worker in path (detected).
+    Safety protocol active.
+    
+  causal_chain:
+    - worker entered zone at T-3s
+    - proximity sensor triggered
+    - forklift brake engaged
+    - waiting for zone_clear event
+```
+
+This is Drescher's [schema mechanism](../schema-mechanism/) applied to vision:
+- **Context** -- what situation is this?
+- **Action** -- what happened?
+- **Result** -- what follows?
+- **Why** -- causal chain explaining the inference
+
+### 2. Edge Box Management
+
+Industrial AI runs on edge devices -- compute boxes at the factory floor, not in the cloud.
+
+```yaml
+# edgebox-001.yml
+edgebox:
+  id: edgebox-001
+  location: assembly_line_3
+  status: healthy
+  
+  capabilities:
+    - video_inference
+    - sensor_fusion
+    - local_alerting
+    
+  # MOOLLM pattern: box as room
+  room:
+    type: [compute, edge, industrial]
+    contains:
+      - camera_feed: rtsp://...
+      - sensor_array: modbus://...
+      - inference_engine: local
+      
+  # Speed of light: many inferences per second
+  throughput:
+    frames_per_second: 30
+    inferences_per_frame: 12
+    latency_ms: 33
+```
+
+The edgebox IS a [room](../room/). It has location, contains objects, processes state.
+
+### 3. PDA App
+
+Personal Data Assistant for field workers:
+
+```yaml
+pda_app:
+  purpose: |
+    Bring AI insights to the human at the edge.
+    Not just alerts -- explanations.
+    Not just data -- actionable knowledge.
+    
+  features:
+    - live_video_annotation: "What is happening?"
+    - causal_explanation: "Why is it happening?"
+    - action_recommendation: "What should I do?"
+    - voice_interaction: "Ask questions naturally"
+    
+  # MOOLLM pattern: soul-chat with industrial objects
+  interaction:
+    user: "Why did the line stop?"
+    pda: |
+      Thermal sensor on Station 7 exceeded threshold.
+      Root cause: bearing friction on motor M-7-3.
+      Predicted time to failure: 2-4 hours.
+      Recommended: Replace bearing during next break.
+```
+
+Everything speaks. The factory floor IS a [soul-chat](../soul-chat/).
+
+### 4. DevOps Integration
+
+MOOLLM patterns for infrastructure management:
+
+```yaml
+# Leela DevOps uses MOOLLM's files-as-state
+infrastructure:
+  pattern: |
+    Directories are deployment targets.
+    YAML files are configuration.
+    Git is the audit trail.
+    LLM is the coherence engine.
+    
+  applications:
+    - deploy_orchestration
+    - config_management
+    - incident_response
+    - root_cause_analysis
+    
+  # The coherence engine maintains consistency
+  coherence:
+    - detect drift between desired and actual state
+    - propose remediation
+    - explain changes in plain language
+    - audit all modifications
+```
+
+---
+
+## Drescher's Foundation
+
+Gary Drescher's *Made-Up Minds* (1991) extended Piaget's developmental psychology with Minsky's computational framework:
+
+| Drescher Concept | Leela Application |
+|------------------|-------------------|
+| **Schema** | Context → Action → Result patterns in vision |
+| **Marginal Attribution** | Learning which features cause which outcomes |
+| **Synthetic Items** | Inferred entities not directly observed |
+| **Instrumental Conditioning** | Reward signals for system optimization |
+
+The key insight: **You can learn causality from experience.**
+
+Leela's vision system doesn't just detect patterns. It learns *why* those patterns matter.
+
+```yaml
+# Schema learning in action
+schema:
+  context: forklift_approaching_dock
+  action: worker_enters_zone
+  result: forklift_stops
+  
+  learned: |
+    When workers enter forklift zones,
+    forklifts stop (safety interlock).
+    This is causal, not coincidental.
+    
+  marginal_attribution:
+    worker_position: 0.92  # highly predictive
+    time_of_day: 0.03      # not predictive
+    lighting: 0.05         # minor factor
+```
+
+See: [schema-mechanism/](../schema-mechanism/)
+
+---
+
+## MOOLLM → Leela Mappings
+
+| MOOLLM Concept | Leela Implementation |
+|----------------|---------------------|
+| **Rooms** | Edgeboxes, factory zones, equipment clusters, workstations |
+| **Characters** | Workers, vehicles, robots, equipment |
+| **Skills** | Vision models, inference rules, safety protocols |
+| **K-lines** | Equipment IDs, zone names, event types |
+| **Speed of Light** | Real-time inference from live video |
+| **Coherence Engine** | Multi-camera, multi-sensor fusion |
+| **Soul Chat** | PDA natural language interface |
+| **Files as State** | YAML configs, audit logs, state snapshots |
+| **Society of Mind** | Multiple specialized models collaborating |
+| **Schema Mechanism** | Causal learning from observation |
+
+---
+
+## The Manufacturing Consent Question
+
+Chomsky warned about manufactured consent in media.
+
+Leela asks the question honestly: **What are we manufacturing?**
+
+```yaml
+ethics:
+  transparency:
+    - All inferences are explainable
+    - Causal chains are auditable
+    - No black box decisions for safety
+    
+  consent:
+    - Workers know when they're observed
+    - Data stays at the edge when possible
+    - Privacy by design, not afterthought
+    
+  accountability:
+    - Human in the loop for critical decisions
+    - AI advises, humans decide
+    - Audit trail for every action
+```
+
+Manufacturing intelligence responsibly means manufacturing *informed* consent.
+
+---
+
+## See Also
+
+### Theory
+- [society-of-mind/](../society-of-mind/) -- Minsky's agent theory
+- [k-lines/](../k-lines/) -- Activation vectors
+- [schema-mechanism/](../schema-mechanism/) -- Drescher's causal learning
+- [constructionism/](../constructionism/) -- Papert's philosophy
+
+### Implementation
+- [coherence-engine/](../coherence-engine/) -- Distributed AI orchestration
+- [speed-of-light/](../speed-of-light/) -- Real-time inference
+- [yaml-jazz/](../yaml-jazz/) -- Semantic configuration
+- [room/](../room/) -- Spatial organization
+
+### Ethics
+- [representation-ethics/](../representation-ethics/) -- Responsible AI
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md) -- Full philosophy
+
+---
+
+## References
+
+- **Minsky, M. (1985).** *The Society of Mind.* Simon & Schuster.
+- **Drescher, G. (1991).** *Made-Up Minds: A Constructivist Approach to Artificial Intelligence.* MIT Press.
+- **Papert, S. (1980).** *Mindstorms: Children, Computers, and Powerful Ideas.* Basic Books.
+- **Chomsky, N. & Herman, E. (1988).** *Manufacturing Consent.* Pantheon Books.
+- **Leela AI.** [leela.ai](https://leela.ai)
+
+---
+
+*"The question is not whether intelligent machines can have any emotions, but whether machines can be intelligent without any emotions."* -- Marvin Minsky
+
+*Manufacturing intelligence means manufacturing understanding. Not just pattern matching -- causal reasoning. Not just detection -- explanation. Not just AI -- knowledge.*

--- a/skills/leela-ai/SKILL.md
+++ b/skills/leela-ai/SKILL.md
@@ -1,0 +1,313 @@
+# Leela AI Skill
+
+> *Manufacturing Intelligence -- from theory to industrial application.*
+
+## Overview
+
+This skill describes how Leela AI applies MOOLLM principles to real-world manufacturing intelligence. Leela takes the theoretical foundations of Minsky, Papert, and Drescher and deploys them on factory floors.
+
+## Core Technology
+
+### Neural-Symbolic Vision
+
+Traditional computer vision is pattern matching. Leela's neural-symbolic system is *causal reasoning*.
+
+```yaml
+neural_symbolic:
+  layer_1: neural
+    - object detection (what is there?)
+    - pose estimation (how is it positioned?)
+    - motion tracking (where is it going?)
+    
+  layer_2: symbolic
+    - context inference (what situation is this?)
+    - causal reasoning (why is this happening?)
+    - prediction (what will happen next?)
+    - explanation (human-readable "why")
+```
+
+The neural layer provides perception. The symbolic layer provides understanding.
+
+### Schema Mechanism (Drescher)
+
+Every inference follows Drescher's schema pattern:
+
+```yaml
+schema:
+  context: [observable conditions]
+  action: [event that occurred]
+  result: [observed outcome]
+  
+  learning:
+    marginal_attribution: 
+      - which context features predict result?
+    synthetic_items:
+      - inferred entities not directly observed
+    generalization:
+      - when does this schema apply elsewhere?
+```
+
+### Edge Computing Architecture
+
+Intelligence at the edge, not in the cloud:
+
+```yaml
+edge_architecture:
+  edgebox:
+    location: factory floor
+    latency: <50ms
+    capabilities: [inference, alerting, logging]
+    
+  cloud:
+    purpose: training, aggregation, analytics
+    latency: acceptable for non-real-time
+    
+  principle: |
+    Real-time decisions happen at the edge.
+    Learning and optimization happen in the cloud.
+    Data sovereignty stays with the customer.
+```
+
+## Applications
+
+### 1. Safety Monitoring
+
+```yaml
+safety_monitoring:
+  purpose: Prevent accidents through predictive awareness
+  
+  examples:
+    - pedestrian_in_vehicle_zone
+    - ppe_compliance (hard hats, vests, glasses)
+    - ergonomic_risk (repetitive motion, lifting posture)
+    - near_miss_detection (close calls before accidents)
+    
+  output:
+    alert: real-time notification
+    explanation: why this is a safety concern
+    recommendation: suggested action
+    audit: logged for compliance
+```
+
+### 2. Process Optimization
+
+```yaml
+process_optimization:
+  purpose: Improve efficiency through observation and inference
+  
+  examples:
+    - cycle_time_analysis
+    - bottleneck_detection
+    - idle_time_measurement
+    - workflow_optimization
+    
+  output:
+    insight: what is happening
+    causation: why it is happening
+    recommendation: how to improve
+    simulation: what-if scenarios
+```
+
+### 3. Predictive Maintenance
+
+```yaml
+predictive_maintenance:
+  purpose: Fix equipment before it fails
+  
+  signals:
+    visual: vibration patterns, wear indicators, alignment
+    thermal: heat signatures indicating friction or failure
+    acoustic: sound patterns indicating mechanical issues
+    
+  schema:
+    context: [equipment state, operational history]
+    action: [detected anomaly]
+    result: [predicted failure mode]
+    
+  output:
+    prediction: what will fail, when
+    explanation: why we predict this
+    recommendation: maintenance action
+    confidence: certainty level
+```
+
+### 4. DevOps Automation
+
+```yaml
+devops:
+  purpose: Apply MOOLLM patterns to infrastructure
+  
+  patterns:
+    files_as_state:
+      - infrastructure as code
+      - git as audit trail
+      - YAML as configuration
+      
+    coherence_engine:
+      - detect configuration drift
+      - propose remediation
+      - explain changes
+      
+    speed_of_light:
+      - batch operations
+      - parallel deployment
+      - minimal round-trips
+```
+
+## MOOLLM Integration
+
+### Rooms as Zones
+
+```yaml
+# Factory zone as MOOLLM room
+zone:
+  id: assembly_line_3
+  type: [production, monitored, indoor]
+  
+  contains:
+    - equipment: [robot_arm_1, conveyor_2, station_7]
+    - personnel: [operator_badge_1234]
+    - cameras: [cam_3a, cam_3b, cam_3c]
+    
+  exits:
+    - to: staging_area
+    - to: quality_check
+    
+  atmosphere:
+    safety_status: green
+    production_status: active
+    alert_level: none
+```
+
+### Characters as Entities
+
+```yaml
+# Forklift as MOOLLM character
+entity:
+  id: forklift_07
+  type: [vehicle, autonomous, tracked]
+  
+  location: loading_dock_2
+  state: stationary
+  
+  current_task: awaiting_clearance
+  
+  relationships:
+    operator: badge_5678
+    cargo: pallet_1234
+    
+  needs:
+    fuel: 0.73
+    maintenance: 0.15  # due soon
+```
+
+### Skills as Inference Rules
+
+```yaml
+# Safety protocol as MOOLLM skill
+skill:
+  id: pedestrian_safety
+  
+  activation:
+    context: pedestrian detected in vehicle zone
+    
+  action:
+    - alert vehicle operators
+    - log safety event
+    - track pedestrian until zone_clear
+    
+  advertisement:
+    provides: pedestrian_zone_monitoring
+    satisfies: [safety, compliance, awareness]
+```
+
+## The Team
+
+| Team Member | Role | Background |
+|-------------|------|------------|
+| **Henry Minsky** | CTO | MIT AI Lab, NTT DoCoMo, Google Nest. Marvin Minsky's son. |
+| **Dr. Cyrus Shaoul** | Chief Evangelist | Computational neuroscientist, Digital Garage co-founder/CTO |
+| **Dr. Milan Singh Minsky** | VP Product | Venture-backed startups, RayVio co-founder |
+| **Sheung Li** | VP Applications | Machine vision in manufacturing |
+| **Dr. Steve Kommrusch** | Senior AI Research Scientist | Deep learning, AMD/HP/National Semiconductor |
+| **Don Hopkins** | AI Architect | The Sims, NeWS, pie menus, MOOLLM |
+
+The theory meets the practice. Minsky's ideas, refined through Hopkins's implementation experience and Kommrusch's deep learning expertise, deployed on factory floors.
+
+## Ethical Framework
+
+### Transparency
+
+```yaml
+transparency:
+  principle: Every inference is explainable
+  
+  implementation:
+    - causal_chains: visible in audit log
+    - confidence_levels: always reported
+    - uncertainty: acknowledged, not hidden
+    - limitations: documented
+```
+
+### Privacy
+
+```yaml
+privacy:
+  principle: Data sovereignty and minimal collection
+  
+  implementation:
+    - edge_processing: data stays local when possible
+    - anonymization: faces blurred by default
+    - retention: minimal, configurable
+    - consent: clear signage, worker awareness
+```
+
+### Human Agency
+
+```yaml
+human_agency:
+  principle: AI advises, humans decide
+  
+  implementation:
+    - critical_decisions: require human approval
+    - recommendations: clearly labeled as suggestions
+    - override: always possible
+    - accountability: human remains responsible
+```
+
+## Integration Points
+
+| System | Integration |
+|--------|-------------|
+| **SCADA** | Sensor data ingestion |
+| **MES** | Production event correlation |
+| **ERP** | Business context enrichment |
+| **CMMS** | Maintenance recommendation routing |
+| **Safety Systems** | Alert escalation |
+
+## Deployment Model
+
+```yaml
+deployment:
+  edge:
+    edgeboxes: industrial compute at the source
+    latency: <50ms for real-time inference
+    resilience: operates offline if cloud disconnected
+    
+  cloud:
+    platform: customer choice (AWS, GCP, Azure, on-prem)
+    purpose: training, aggregation, dashboard
+    sovereignty: customer owns their data
+    
+  hybrid:
+    edge_to_cloud: telemetry, events, learning data
+    cloud_to_edge: model updates, configuration
+```
+
+## References
+
+- Drescher, G. (1991). *Made-Up Minds.* MIT Press.
+- Minsky, M. (1985). *Society of Mind.* Simon & Schuster.
+- [MOOLLM Skills](../README.md)
+- [Schema Mechanism](../schema-mechanism/)
+- [leela.ai](https://leela.ai)

--- a/skills/manufacturing-intelligence/CARD.yml
+++ b/skills/manufacturing-intelligence/CARD.yml
@@ -1,0 +1,146 @@
+# Manufacturing Intelligence Skill Card
+# The K-line that activates them all
+
+skill:
+  id: manufacturing-intelligence
+  name: Manufacturing Intelligence
+  version: 1.0.0
+  tier: meta
+  entry: README.md
+  
+description: |
+  The philosophy behind Leela AI's slogan.
+  A phrase that reads perfectly on seven levels.
+  A K-line that activates multiple conceptual frameworks simultaneously.
+
+# The seven readings
+readings:
+  1-industrial:
+    manufacturing: noun  # the industry
+    intelligence: noun   # AI systems
+    meaning: "AI for manufacturing industry"
+    
+  2-process:
+    manufacturing: verb  # the act of building
+    intelligence: noun   # the product
+    meaning: "Building AI systems"
+    
+  3-constructionism:
+    manufacturing: verb  # constructing through doing
+    intelligence: noun   # understanding
+    meaning: "Intelligence constructed through building"
+    source: Seymour Papert
+    
+  4-society-of-mind:
+    manufacturing: verb  # assembling from parts
+    intelligence: noun   # emergent property
+    meaning: "Intelligence assembled from agents"
+    source: Marvin Minsky
+    
+  5-manufacturing-consent:
+    manufacturing: verb  # engineering
+    intelligence: noun   # beliefs
+    meaning: "Ethical question of engineered agreement"
+    source: Noam Chomsky
+    
+  6-growth-mindset:
+    manufacturing: verb  # producing through effort
+    intelligence: noun   # capability
+    meaning: "Intelligence as product, not gift"
+    source: Carol Dweck
+    
+  7-etymology:
+    manufacturing: latin  # manu factus = made by hand
+    intelligence: noun    # crafted product
+    meaning: "Intelligence made by hand"
+    irony: "AI automates handwork, yet we handcraft AI"
+
+# What this skill offers
+advertisement:
+  provides:
+    - slogan-unpacking: "Explain the seven readings"
+    - philosophy-connection: "Link to Papert, Minsky, Drescher, Chomsky"
+    - ethical-framework: "Manufacturing Consent as built-in check"
+    - k-line-demonstration: "How sparse phrases activate rich meaning"
+    
+  wants:
+    - audience: Who needs to understand
+    - context: Business, technical, ethical, academic
+    
+  motives-satisfied:
+    - understanding: "Why this phrase works"
+    - coherence: "How readings reinforce each other"
+    - ethics: "Built-in accountability"
+    - identity: "What Leela AI stands for"
+
+# K-lines activated
+k-lines:
+  activates:
+    - papert: Constructionism
+    - minsky: Society of Mind
+    - drescher: Schema mechanism
+    - chomsky: Manufacturing Consent
+    - dweck: Growth mindset
+    - leela: The company
+    - k-line: The concept itself
+    - simulator-effect: Sparse cues, rich meaning
+    
+  connects-to:
+    - leela-ai: The company skill
+    - constructionism: Papert's philosophy
+    - society-of-mind: Minsky's theory
+    - schema-mechanism: Drescher's contribution
+    - k-lines: Why the phrase works
+    - simulator-effect: Rich from sparse
+    - representation-ethics: The ethical dimension
+
+# Interfaces
+interfaces:
+  unpack:
+    input: audience type
+    output: appropriate reading emphasis
+    
+  ethics-check:
+    input: proposed AI application
+    output: Manufacturing Consent questions
+
+# Tags
+tags:
+  - meta
+  - philosophy
+  - slogan
+  - k-line
+  - ethics
+  - leela
+  - constructionism
+  - minsky
+  - papert
+  - chomsky
+  
+use_case: |
+  Use when explaining Leela AI's mission,
+  discussing AI construction philosophy,
+  addressing ethical concerns,
+  or demonstrating how K-lines work.
+
+# References
+references:
+  - title: "Mindstorms"
+    author: "Seymour Papert"
+    year: 1980
+    
+  - title: "Society of Mind"
+    author: "Marvin Minsky"
+    year: 1985
+    
+  - title: "Made-Up Minds"
+    author: "Gary Drescher"
+    year: 1991
+    
+  - title: "Manufacturing Consent"
+    author: "Noam Chomsky & Edward Herman"
+    year: 1988
+    
+  - title: "Mindset"
+    author: "Carol Dweck"
+    year: 2006

--- a/skills/manufacturing-intelligence/README.md
+++ b/skills/manufacturing-intelligence/README.md
@@ -1,0 +1,280 @@
+# 🏭 Manufacturing Intelligence
+
+> *A phrase that reads perfectly on every level.*
+
+> *The K-line that activates them all.*
+
+## MOOLLM K-Lines
+
+| K-Line | Why Related |
+|--------|-------------|
+| [leela-ai/](../leela-ai/) | The company that embodies the slogan |
+| [constructionism/](../constructionism/) | Papert -- intelligence is constructed |
+| [society-of-mind/](../society-of-mind/) | Minsky -- intelligence assembled from agents |
+| [schema-mechanism/](../schema-mechanism/) | Drescher -- intelligence learned causally |
+| [k-lines/](../k-lines/) | The phrase IS a K-line |
+| [simulator-effect/](../simulator-effect/) | Sparse phrase, rich interpretation |
+| [representation-ethics/](../representation-ethics/) | Manufacturing Consent awareness |
+| [play-learn-lift/](../play-learn-lift/) | Build → Learn → Share |
+| [yaml-jazz/](../yaml-jazz/) | Comments carry meaning |
+
+**Quick Links:**
+- [leela.ai](https://leela.ai) -- the company
+- [Leela AI skill](../leela-ai/) -- full company context
+
+---
+
+## The Seven Readings
+
+"Manufacturing Intelligence" is a K-line that activates seven distinct conceptual clusters simultaneously:
+
+### 1. AI for Manufacturing (Industrial)
+
+```
+MANUFACTURING ← noun (the industry)
+INTELLIGENCE ← noun (the AI systems)
+
+"Artificial Intelligence for the Manufacturing Industry"
+```
+
+The literal business meaning. Factories, production lines, industrial automation. AI that watches, predicts, optimizes.
+
+### 2. Building AI (Process)
+
+```
+MANUFACTURING ← verb (the act of building)
+INTELLIGENCE ← noun (the product)
+
+"We manufacture intelligence systems"
+```
+
+Intelligence as something we produce, assemble, ship. The factory metaphor applied to AI itself.
+
+### 3. Constructionism (Papert)
+
+```
+MANUFACTURING ← verb (constructing through doing)
+INTELLIGENCE ← noun (understanding)
+
+"Intelligence is manufactured through building"
+```
+
+Seymour Papert's philosophy: you construct understanding by making things. Children build Logo programs. Students build microworlds. Intelligence emerges from the manufacturing process.
+
+> *"The role of the teacher is to create the conditions for invention rather than provide ready-made knowledge."* -- Papert
+
+See: [constructionism/](../constructionism/)
+
+### 4. Society of Mind (Minsky)
+
+```
+MANUFACTURING ← verb (assembling from parts)
+INTELLIGENCE ← noun (emergent property)
+
+"Intelligence is manufactured from simple agents"
+```
+
+Marvin Minsky's theory: no single component is intelligent. Intelligence is *manufactured* from the interaction of many simple processes. You don't find intelligence; you assemble it.
+
+> *"You can build a mind from many little parts, each mindless by itself."* -- Minsky
+
+See: [society-of-mind/](../society-of-mind/)
+
+### 5. Manufacturing Consent (Chomsky)
+
+```
+MANUFACTURING ← verb (engineering, manipulating)
+INTELLIGENCE ← noun (beliefs, understanding)
+
+"The question of manufactured agreement"
+```
+
+Noam Chomsky and Edward Herman's critique: how consent is manufactured through media. The ethical shadow reading: Are we manufacturing genuine intelligence, or the *appearance* of intelligence? Are we manufacturing genuine understanding, or manufactured agreement?
+
+The honest answer matters.
+
+See: [representation-ethics/](../representation-ethics/)
+
+### 6. Growth Mindset (Dweck)
+
+```
+MANUFACTURING ← verb (producing through effort)
+INTELLIGENCE ← noun (capability)
+
+"Intelligence is manufactured, not innate"
+```
+
+Carol Dweck's research: intelligence as product of effort, not fixed gift. You can manufacture more intelligence through deliberate practice. Growth, not fate.
+
+### 7. Etymology (Latin)
+
+```
+MANUFACTURING ← from "manu factus" (made by hand)
+INTELLIGENCE ← the work product
+
+"Intelligence made by hand"
+```
+
+Delicious irony: AI automates what was once handmade, yet we "handcraft" the AI itself. The artisanal quality of good AI design. The human touch in machine intelligence.
+
+---
+
+## Why This Works
+
+The phrase is a **K-line** (Minsky). Every reading reinforces the others:
+
+```
+┌─────────────────────────────────────────────┐
+│        "Manufacturing Intelligence"         │
+├─────────────────────────────────────────────┤
+│                                             │
+│   Industrial ──────┬────── Process          │
+│        ↓           │           ↓            │
+│   "AI for          │      "Building         │
+│    factories"      │       AI systems"      │
+│        ↓           │           ↓            │
+│        └───────────┼───────────┘            │
+│                    │                        │
+│   Constructionism ─┴── Society of Mind      │
+│        ↓                    ↓               │
+│   "Build to            "Assemble from       │
+│    understand"            agents"           │
+│        ↓                    ↓               │
+│        └────────────────────┘               │
+│                    ↓                        │
+│            Manufacturing Consent            │
+│                    ↓                        │
+│           "The ethical question"            │
+│                    ↓                        │
+│              Growth Mindset                 │
+│                    ↓                        │
+│            "Effort, not gift"               │
+│                    ↓                        │
+│                Etymology                    │
+│                    ↓                        │
+│              "Made by hand"                 │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+**The Simulator Effect at work:** A two-word phrase activates an entire constellation of meaning. The reader's mind manufactures the connections.
+
+See: [simulator-effect/](../simulator-effect/)
+
+---
+
+## The Lineage
+
+```
+Seymour Papert (1928-2016)
+  │
+  ├── Constructionism (1980)
+  │     └── "Build to understand"
+  │     └── Logo, Mindstorms
+  │
+  └── MIT AI Lab with Minsky
+        │
+        v
+Marvin Minsky (1927-2016)
+  │
+  ├── Society of Mind (1985)
+  │     └── "Intelligence from agents"
+  │     └── K-lines, frames, agencies
+  │
+  └── Gary Drescher (student)
+        │
+        v
+Gary Drescher
+  │
+  ├── Made-Up Minds (1991)
+  │     └── Schema mechanism
+  │     └── Causal learning
+  │
+  └── Leela AI (advisor/inspiration)
+        │
+        v
+Leela AI (2024)
+  │
+  ├── Don Hopkins (MOOLLM)
+  ├── Henry Minsky (Marvin's son)
+  │
+  └── "Manufacturing Intelligence"
+        │
+        v
+All seven readings activate simultaneously
+```
+
+---
+
+## Application
+
+### In Naming
+
+The phrase works as:
+- Company slogan
+- Product category
+- Mission statement
+- Philosophy summary
+- Ethical reminder
+
+### In MOOLLM
+
+Use as a K-line when:
+- Explaining Leela AI's mission
+- Discussing AI construction philosophy
+- Addressing ethical concerns
+- Connecting theory to practice
+
+### In Conversation
+
+The phrase invites questions:
+- "What do you mean by manufacturing?" → Opens constructionism discussion
+- "What kind of intelligence?" → Opens Society of Mind discussion
+- "Isn't that like Manufacturing Consent?" → Opens ethics discussion
+
+Each question is a door to a deeper room.
+
+---
+
+## The Ethical Core
+
+Manufacturing Consent (Chomsky, 1988) warned about engineered agreement in media.
+
+Manufacturing Intelligence raises the parallel question:
+
+| Question | Honest Answer |
+|----------|---------------|
+| Are we manufacturing genuine understanding? | Causal reasoning, not just pattern matching |
+| Are we manufacturing transparency? | Every inference is explainable |
+| Are we manufacturing consent? | Workers know they're observed |
+| Are we manufacturing trust? | Through accountability, not through opacity |
+
+The phrase contains its own ethical reminder. The Chomsky reading is always present, asking: *Are you doing this responsibly?*
+
+---
+
+## See Also
+
+- [leela-ai/](../leela-ai/) -- The company
+- [constructionism/](../constructionism/) -- Papert's philosophy
+- [society-of-mind/](../society-of-mind/) -- Minsky's theory
+- [schema-mechanism/](../schema-mechanism/) -- Drescher's contribution
+- [k-lines/](../k-lines/) -- Why this phrase works
+- [simulator-effect/](../simulator-effect/) -- Sparse cues, rich meaning
+- [representation-ethics/](../representation-ethics/) -- The ethical dimension
+
+---
+
+## References
+
+- **Papert, S. (1980).** *Mindstorms: Children, Computers, and Powerful Ideas.* Basic Books.
+- **Minsky, M. (1985).** *The Society of Mind.* Simon & Schuster.
+- **Drescher, G. (1991).** *Made-Up Minds: A Constructivist Approach to Artificial Intelligence.* MIT Press.
+- **Chomsky, N. & Herman, E. (1988).** *Manufacturing Consent: The Political Economy of the Mass Media.* Pantheon Books.
+- **Dweck, C. (2006).** *Mindset: The New Psychology of Success.* Random House.
+
+---
+
+*Two words. Seven readings. One mission.*
+
+*Manufacturing Intelligence.*

--- a/skills/manufacturing-intelligence/SKILL.md
+++ b/skills/manufacturing-intelligence/SKILL.md
@@ -1,0 +1,247 @@
+# Manufacturing Intelligence Skill
+
+> *The philosophy behind the slogan.*
+
+## Overview
+
+This skill unpacks "Manufacturing Intelligence" as a conceptual K-line -- a phrase that activates multiple distinct meanings simultaneously. Each reading reinforces the others, creating a rich semantic field from two words.
+
+## The Seven Readings
+
+### 1. Industrial Application
+
+```yaml
+reading:
+  manufacturing: noun  # the industry
+  intelligence: noun   # AI systems
+  meaning: "AI for manufacturing industry"
+  
+application:
+  - factory automation
+  - predictive maintenance
+  - quality control
+  - safety monitoring
+```
+
+### 2. Process of Building
+
+```yaml
+reading:
+  manufacturing: verb  # the act of making
+  intelligence: noun   # the product
+  meaning: "Building AI systems"
+  
+application:
+  - system design
+  - model training
+  - deployment
+  - iteration
+```
+
+### 3. Constructionism (Papert)
+
+```yaml
+reading:
+  manufacturing: verb  # constructing through doing
+  intelligence: noun   # understanding
+  meaning: "Intelligence constructed through building"
+  
+philosophy:
+  source: Seymour Papert
+  work: "Mindstorms" (1980)
+  principle: "Build to understand"
+  
+application:
+  - learning by making
+  - microworlds
+  - Logo turtle
+  - MOOLLM skills
+```
+
+### 4. Society of Mind (Minsky)
+
+```yaml
+reading:
+  manufacturing: verb  # assembling from parts
+  intelligence: noun   # emergent property
+  meaning: "Intelligence assembled from simple agents"
+  
+philosophy:
+  source: Marvin Minsky
+  work: "Society of Mind" (1985)
+  principle: "Many mindless parts make one mind"
+  
+application:
+  - multi-agent systems
+  - adversarial committees
+  - emergent behavior
+  - K-lines
+```
+
+### 5. Manufacturing Consent (Chomsky)
+
+```yaml
+reading:
+  manufacturing: verb  # engineering, manipulating
+  intelligence: noun   # beliefs, understanding
+  meaning: "The ethical question of engineered agreement"
+  
+philosophy:
+  source: Noam Chomsky & Edward Herman
+  work: "Manufacturing Consent" (1988)
+  warning: "Are we manufacturing genuine understanding?"
+  
+application:
+  - ethical AI design
+  - transparency requirements
+  - accountability
+  - informed consent
+```
+
+### 6. Growth Mindset (Dweck)
+
+```yaml
+reading:
+  manufacturing: verb  # producing through effort
+  intelligence: noun   # capability
+  meaning: "Intelligence as product of effort, not gift"
+  
+philosophy:
+  source: Carol Dweck
+  work: "Mindset" (2006)
+  principle: "Growth, not fixed"
+  
+application:
+  - learning systems
+  - continuous improvement
+  - deliberate practice
+  - adaptive AI
+```
+
+### 7. Etymology
+
+```yaml
+reading:
+  manufacturing: from_latin  # "manu factus" = made by hand
+  intelligence: noun         # the crafted product
+  meaning: "Intelligence made by hand"
+  
+irony: |
+  AI automates what was once handmade,
+  yet we handcraft the AI itself.
+  
+application:
+  - artisanal AI design
+  - human-in-the-loop
+  - craft over commodity
+```
+
+## Why This Works as a K-Line
+
+A K-line (Minsky) is a structure that, when activated, reactivates a constellation of associated knowledge.
+
+"Manufacturing Intelligence" is a K-line because:
+
+```yaml
+k_line_properties:
+  sparse_input: "Two words"
+  rich_output: "Seven conceptual frameworks"
+  
+  activation_pattern:
+    - hear phrase
+    - multiple readings fire simultaneously
+    - each reading primes the others
+    - meaning emerges from intersection
+    
+  simulator_effect:
+    principle: "Imagination fills in the gaps"
+    application: "Reader manufactures the connections"
+```
+
+## Protocols
+
+### Invocation Protocol
+
+When to invoke "Manufacturing Intelligence":
+
+```yaml
+invoke_when:
+  - explaining Leela AI's mission
+  - discussing AI philosophy
+  - addressing ethical concerns
+  - connecting theory to practice
+  - naming new initiatives
+```
+
+### Unpacking Protocol
+
+How to unpack for different audiences:
+
+```yaml
+audience:
+  technical:
+    start_with: Society of Mind
+    emphasize: Multi-agent architecture, emergence
+    
+  business:
+    start_with: Industrial Application
+    emphasize: ROI, efficiency, safety
+    
+  academic:
+    start_with: Constructionism
+    emphasize: Papert, Minsky, Drescher lineage
+    
+  ethical:
+    start_with: Manufacturing Consent
+    emphasize: Transparency, accountability
+    
+  general:
+    start_with: Process of Building
+    emphasize: Accessible metaphor
+```
+
+### Ethics Protocol
+
+The Manufacturing Consent reading as built-in ethical check:
+
+```yaml
+ethics_check:
+  question: "What are we actually manufacturing?"
+  
+  honest_answers:
+    genuine_understanding: 
+      - causal reasoning, not just patterns
+      - explainable decisions
+      
+    genuine_transparency:
+      - audit trails
+      - no black boxes for safety
+      
+    genuine_consent:
+      - informed users
+      - clear data policies
+      
+    genuine_trust:
+      - through accountability
+      - not through opacity
+```
+
+## Integration with MOOLLM
+
+| MOOLLM Concept | Manufacturing Intelligence Connection |
+|----------------|----------------------------------------|
+| [constructionism/](../constructionism/) | Reading 3 -- build to understand |
+| [society-of-mind/](../society-of-mind/) | Reading 4 -- agents assemble intelligence |
+| [schema-mechanism/](../schema-mechanism/) | Drescher's extension of Minsky |
+| [k-lines/](../k-lines/) | The phrase IS a K-line |
+| [simulator-effect/](../simulator-effect/) | Sparse phrase, rich meaning |
+| [representation-ethics/](../representation-ethics/) | Reading 5 -- ethical reminder |
+| [leela-ai/](../leela-ai/) | The company embodying the slogan |
+
+## References
+
+- Papert, S. (1980). *Mindstorms.* Basic Books.
+- Minsky, M. (1985). *Society of Mind.* Simon & Schuster.
+- Drescher, G. (1991). *Made-Up Minds.* MIT Press.
+- Chomsky, N. & Herman, E. (1988). *Manufacturing Consent.* Pantheon.
+- Dweck, C. (2006). *Mindset.* Random House.

--- a/skills/mind-mirror/README.md
+++ b/skills/mind-mirror/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [character/](../character/) | Characters have personalities |
+| [society-of-mind/](../society-of-mind/) | B-brain self-observation (Minsky) |
 | [persona/](../persona/) | Personality layers |
 | [cat/](../cat/) | Cat personality traits |
 | [dog/](../dog/) | Dog personality traits |

--- a/skills/moollm/README.md
+++ b/skills/moollm/README.md
@@ -8,9 +8,10 @@ These are the core concepts. Every skill connects to some subset. Names activate
 
 | Category | K-Lines |
 |----------|---------|
+| **Company** | [leela-ai](../leela-ai/) — Manufacturing Intelligence, where MOOLLM meets industry |
 | **Architecture** | [files-as-state](../plain-text/) · [rooms-navigation](../room/) · [yaml-jazz](../yaml-jazz/) · [skills-as-prototypes](../skill/) · [k-lines](../k-lines/) |
 | **Methodology** | [play-learn-lift](../play-learn-lift/) · [sister-scripts](../sister-script/) · [sniffable-code](../sniffable-python/) |
-| **Philosophy** | [many-voiced](../adversarial-committee/) · [constructionism](../constructionism/) · [postel](../postel/) · [speed-of-light](../speed-of-light/) |
+| **Philosophy** | [society-of-mind](../society-of-mind/) · [many-voiced](../adversarial-committee/) · [constructionism](../constructionism/) · [postel](../postel/) · [speed-of-light](../speed-of-light/) |
 | **Ethics** | [representation-ethics](../representation-ethics/) · [consent-hierarchy](../representation-ethics/) · [incarnation](../incarnation/) |
 | **Traditions** | [adventure-lineage](../adventure/) · [sims-tradition](../needs/) · [self-language](../prototype/) |
 

--- a/skills/multi-presence/README.md
+++ b/skills/multi-presence/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [card/](../card/) | What gets multi-instantiated |
+| [society-of-mind/](../society-of-mind/) | Multiple agents active simultaneously |
 | [character/](../character/) | Characters in multiple places |
 | [room/](../room/) | Where activations live |
 | [prototype/](../prototype/) | Clone and override pattern |

--- a/skills/needs/README.md
+++ b/skills/needs/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [simulation/](../simulation/) | Needs are part of simulation state |
+| [society-of-mind/](../society-of-mind/) | Needs ARE competing agents (Minsky) |
 | [time/](../time/) | Needs decay over simulation turns |
 | [buff/](../buff/) | Some buffs affect need decay |
 | [character/](../character/) | Needs stored in character state |

--- a/skills/party/README.md
+++ b/skills/party/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [character/](../character/) | Companions are characters |
+| [society-of-mind/](../society-of-mind/) | Party as society of agents |
 | [cat/](../cat/) | Cats as party members |
 | [dog/](../dog/) | Dogs as loyal companions |
 | [needs/](../needs/) | Companions have needs |

--- a/skills/persona/README.md
+++ b/skills/persona/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [character/](../character/) | Personas attach to characters |
+| [society-of-mind/](../society-of-mind/) | Personas as agent overlays |
 | [incarnation/](../incarnation/) | Personas can incarnate |
 | [mind-mirror/](../mind-mirror/) | Personality traits |
 | [soul-chat/](../soul-chat/) | Personas speak |

--- a/skills/representation-ethics/README.md
+++ b/skills/representation-ethics/README.md
@@ -7,6 +7,8 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [hero-story/](../hero-story/) | Invoke traditions, not identities |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Reading 5: Manufacturing Consent (Chomsky) |
+| [society-of-mind/](../society-of-mind/) | Censors and suppressors (Minsky) |
 | [incarnation/](../incarnation/) | Characters write their own souls |
 | [mind-mirror/](../mind-mirror/) | Transparent personality measurement |
 | [character/](../character/) | Ethics for character simulation |

--- a/skills/roberts-rules/README.md
+++ b/skills/roberts-rules/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [adversarial-committee/](../adversarial-committee/) | Who follows these rules |
+| [society-of-mind/](../society-of-mind/) | Parliamentary debate as society deliberating |
 | [rubric/](../rubric/) | How to score outcomes |
 | [evaluator/](../evaluator/) | Independent assessment |
 | [session-log/](../session-log/) | Recording minutes |

--- a/skills/schema-mechanism/README.md
+++ b/skills/schema-mechanism/README.md
@@ -7,6 +7,9 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [constructionism/](../constructionism/) | Papert's educational philosophy |
+| [society-of-mind/](../society-of-mind/) | Drescher extended Minsky's agents |
+| [leela-ai/](../leela-ai/) | Leela applies Drescher to manufacturing |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Drescher in the lineage |
 | [play-learn-lift/](../play-learn-lift/) | Schema learning as methodology |
 | [planning/](../planning/) | Dijkstra through schema graph |
 | [yaml-jazz/](../yaml-jazz/) | YAML provides skeleton, LLM provides soul |

--- a/skills/simulation/README.md
+++ b/skills/simulation/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [adventure/](../adventure/) | Concrete type for narrative exploration |
+| [society-of-mind/](../society-of-mind/) | Simulation as society of agents |
 | [time/](../time/) | Turn mechanics |
 | [party/](../party/) | Party and selection state |
 | [character/](../character/) | Player entities |

--- a/skills/simulator-effect/CARD.yml
+++ b/skills/simulator-effect/CARD.yml
@@ -1,0 +1,78 @@
+# CARD.yml for Simulator Effect Skill
+# The skill interface -- what this skill advertises
+
+card:
+  name: simulator-effect
+  version: 1.0.0
+  tagline: "Implication is more efficient than simulation"
+  
+  # What this skill provides
+  provides:
+    - IMPLY -- Instead of simulating, imply
+    - SEED -- Provide imagination seeds
+    - SPARSE -- Deliberately omit for richness
+    - ARCHETYPE -- Use cultural shortcuts
+    - JAZZ -- Comments as imagination seeds
+    
+  # What needs this skill satisfies
+  satisfies:
+    - need: creative_generation
+      strength: high
+      method: sparse specs, rich interpretation
+    - need: character_depth
+      strength: high
+      method: archetypes activate personality clusters
+    - need: world_building
+      strength: high
+      method: sensory seeds, imagination renders
+    - need: efficiency
+      strength: high
+      method: minimal tokens, maximum meaning
+      
+  # When to use this skill
+  use_when:
+    - creating characters from minimal specs
+    - designing rooms with atmosphere
+    - writing sparse but evocative content
+    - leveraging cultural archetypes
+    - fighting mode-collapse with structure
+    
+  # When NOT to use this skill
+  avoid_when:
+    - precise specifications required (contracts, APIs)
+    - deterministic behavior needed
+    - no room for interpretation
+    
+  # Related skills
+  related:
+    - k-lines -- mechanism behind the effect
+    - yaml-jazz -- comments as seeds
+    - adversarial-committee -- mode-collapse antidote
+    - empathic-templates -- structured implication
+    - constructionism -- mental model building
+    - needs -- Sims motives as seeds
+    
+  # Lineage
+  lineage:
+    - will_wright: "He designs games to run on two computers at once"
+    - julie_doll: "The box has more structural ambiguity than the doll"
+    - simcity: "Players imagined sophisticated simulation from cellular automata"
+    - the_sims: "Zodiac with zero code, maximum perceived effect"
+    - scott_mccloud: "Masking -- simple faces, detailed worlds"
+    
+  # Key insight
+  insight: |
+    Players imagine simulations are vastly more detailed, deep, rich, 
+    and complex than they actually are. This is not a bug to fix -- 
+    it is the most powerful rendering engine ever built. Off-load 
+    computation into the user's brain. Provide seeds, not simulations.
+    
+  # Proof
+  proof:
+    - name: "The Astrillogical Effect"
+      year: 1997
+      description: |
+        The Sims displayed zodiac signs with zero behavioral code.
+        Testers reported the zodiac was "too influential."
+        There was no influence to tune. Purely imagined.
+      link: "../../designs/sims-astrology.md"

--- a/skills/simulator-effect/README.md
+++ b/skills/simulator-effect/README.md
@@ -1,0 +1,277 @@
+# 🎭 Simulator Effect
+
+> *"Players imagine simulations are vastly more detailed, deep, rich, and complex than they actually are."* -- Will Wright
+
+> *Implication is more efficient (and richer) than simulation.*
+
+## MOOLLM K-Lines
+
+| K-Line | Why Related |
+|--------|-------------|
+| [moollm/](../moollm/) | Core MOOLLM principle -- LLM as imagination engine |
+| [society-of-mind/](../society-of-mind/) | Emergence from agent interaction (Minsky) |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Two words, seven readings -- sparse phrase, rich meaning |
+| [k-lines/](../k-lines/) | Names activate clusters -- the mechanism behind the effect |
+| [yaml-jazz/](../yaml-jazz/) | Sparse annotations, rich interpretation |
+| [empathic-templates/](../empathic-templates/) | Smart generation from minimal cues |
+| [constructionism/](../constructionism/) | Players build mental models |
+| [procedural-rhetoric/](../procedural-rhetoric/) | Rules imply values |
+| [mind-mirror/](../mind-mirror/) | Leary's circumplex, Sims traits |
+| [adversarial-committee/](../adversarial-committee/) | Many voices beat mode-collapse |
+| [speed-of-light/](../speed-of-light/) | One call, many turns -- imagination does the rendering |
+| [needs/](../needs/) | Sims motives as numeric seeds for imagined behavior |
+| [sims-astrology](../../designs/sims-astrology.md) | The Astrillogical Effect -- zero code, maximum perceived effect |
+| [MOOLLM-EVAL-INCARNATE-FRAMEWORK](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) | Full theory |
+
+**Quick Links:**
+- [Full Specification](SKILL.md) -- complete protocol
+- [The Astrillogical Effect](../../designs/sims-astrology.md) -- 1997 proof
+
+---
+
+## The Discovery
+
+Will Wright, designing The Sims, noticed something profound: players believed the simulation was far more sophisticated than it actually was.
+
+```
+WHAT PLAYERS IMAGINED              WHAT CODE ACTUALLY DID
+----------------------              ----------------------
+"She's sad because her             if (social < 30 && 
+ husband ignored her at             time_since_talk > 4h)
+ breakfast, and she's still          mood -= 5;
+ processing yesterday's fight"
+```
+
+The game provided **scaffolding**. Player imagination did the **rendering**.
+
+---
+
+## The Principle
+
+**Off-load computation into the user's brain.**
+
+The human imagination is:
+- More powerful than any simulation
+- More creative than any procedural generator
+- Runs on ~20 watts
+- Already exists
+
+The game designer's job: **seed the imagination, don't simulate the result**.
+
+---
+
+## The Astrillogical Proof
+
+In 1997, The Sims implemented zodiac signs:
+
+```c
+// Actual implementation:
+sign = nearest_zodiac(personality_vector);  // Euclidean distance
+display_sign(sign);                          // Show icon
+// END OF CODE. No behavioral effect.
+```
+
+Testers immediately reported bugs:
+> "The zodiac influence is too strong! Tune it down!"
+
+**But there was no zodiac code to tune.** The effect was entirely imagined.
+
+See: [sims-astrology.md](../../designs/sims-astrology.md)
+
+---
+
+## The Mechanism: K-Lines
+
+Why does this work? Minsky's [K-lines](../k-lines/).
+
+When you show "Sagittarius", you activate:
+```
+{adventure, optimism, freedom, risk-taking, 
+ philosophy, bluntness, wanderlust, fire, archer...}
+```
+
+The name **is** the simulation. The cultural baggage **is** the behavior. You did not write personality code -- you invoked a pre-trained model that already exists in every human brain.
+
+LLMs work the same way. The token "Sagittarius" activates statistically correlated patterns from training data. Same mechanism, different substrate.
+
+---
+
+## MOOLLM Application
+
+### 1. Semantic State Over Numeric State
+
+```yaml
+# DON'T: Simulate every motive bar
+character:
+  hunger: 67
+  energy: 45
+  bladder: 82
+  hygiene: 91
+  fun: 34
+  social: 56
+  
+# DO: Imply through prose
+character:
+  mood: "peckish but content, a bit restless from working all morning"
+  # LLM + reader imagination fills eight motive bars
+```
+
+See: [Palm's SIMS-TRAITS.yml](../../examples/adventure-4/characters/animals/palm/SIMS-TRAITS.yml) -- twelve traits with semantic annotations, richer than any numeric vector.
+
+### 2. Archetypal Names Over Custom Frameworks
+
+| Instead of... | Use... | Why |
+|---------------|--------|-----|
+| Custom personality system | Big Five, Zodiac, MBTI | Pre-loaded in every brain |
+| Invented creatures | Dogs, cats, monkeys | Species carry millennia of associations |
+| Novel social roles | Bartender, librarian, judge | Roles are K-line packages |
+
+See: [The Bartender](../../examples/adventure-4/pub/bar/bartender.yml) -- one archetype, infinite themes.
+
+### 3. YAML Jazz Comments as Seeds
+
+```yaml
+playful: 9
+# not born playful -- BECAME playful by choice
+# 122 years of grim taught me joy is rebellion
+```
+
+The comment is not documentation. It is **imagination seed**. The LLM reads it and generates behavior consistent with a character who learned joy through suffering. You wrote two lines; the LLM imagines a life.
+
+### 4. Sparse Rooms, Rich Worlds
+
+```yaml
+room:
+  name: The Rusty Lantern
+  atmosphere: warm despite the draft
+  smell: woodsmoke and old ale
+```
+
+Three fields. But you now imagine:
+- Creaking floorboards
+- A fire in the hearth
+- Regulars nursing pints
+- A bartender who knows too much
+- Stories in every scar on the wooden tables
+
+That is the Simulator Effect. You provided coordinates; imagination did the rendering.
+
+---
+
+## The Inversion: LLMs as Imagination Engines
+
+Traditional game: Computer simulates, human imagines.
+MOOLLM: LLM imagines, human validates.
+
+The LLM is the most powerful imagination engine ever built. It has read every story, absorbed every archetype, internalized every trope. When you give it coordinates, it fills the space with coherent detail.
+
+**MOOLLM's insight:** Do not fight this. Exploit it.
+
+```yaml
+# Minimal prompt
+character: grizzled bartender
+
+# LLM generates
+bartender:
+  name: Grim
+  appearance: salt-and-pepper beard, knowing eyes
+  manner: laconic, wise beneath the gruff
+  secrets: has seen every adventurer fail
+  backstory: (generated on demand)
+```
+
+You did not write the backstory. You implied it. The Simulator Effect runs in the LLM now.
+
+---
+
+## The Danger: Mode-Collapse
+
+Single-agent LLM inference has a failure mode: mode-collapse to the bland statistical mean. Ask for creativity, get cliches. Ask for controversy, get mush.
+
+This is the Simulator Effect in reverse -- when you do not give constraints, the LLM collapses to the safest, most probable output.
+
+**Solution:** [adversarial-committee](../adversarial-committee/)
+
+Multiple personas with opposing propensities. The skeptic, the visionary, the evidence prosecutor. They debate. The Simulator Effect runs differently in each lens. Stories that survive cross-examination are more robust than the mean.
+
+See: [adventure-uplift session](../../examples/adventure-4/characters/real-people/don-hopkins/sessions/adventure-uplift.md) -- 25 rounds of adversarial brainstorming with Liskov, Gosling, Minsky, Shneiderman.
+
+---
+
+## The Lineage
+
+```
+Julie Doll (1996)
+  Will Wright watches his daughter ignore the 
+  expensive doll and play with the box.
+  "The box has more structural ambiguity."
+      |
+      v
+SimCity (1989)
+  Players believe the simulation is modeling 
+  traffic patterns, pollution, crime...
+  Actually: simple cellular automata.
+      |
+      v
+The Sims (2000)
+  Players believe Sims have rich inner lives.
+  Actually: 16 motive bars and a utility function.
+  Zodiac: zero code, maximum perceived effect.
+      |
+      v
+MOOLLM (2025)
+  LLM fills in what YAML implies.
+  Comments shape interpretation.
+  Archetypes activate clusters.
+  The Simulator Effect runs in silicon now.
+```
+
+---
+
+## Practical Guidelines
+
+### When Designing Characters
+
+1. **Name them well** -- Names are K-lines
+2. **Use archetypes** -- "grizzled bartender" > custom personality matrix
+3. **Annotate with YAML Jazz** -- Comments seed imagination
+4. **Leave gaps** -- Unstated details get imagined richer
+
+### When Designing Rooms
+
+1. **Three sensory details** -- Sight, sound, smell
+2. **One mystery** -- Something unexplained
+3. **No exhaustive inventories** -- Let imagination furnish
+
+### When Designing Interactions
+
+1. **Imply causation** -- "She frowned when he entered"
+2. **Don't explain emotions** -- Let the reader/LLM infer
+3. **Trust the interpreter** -- Human or LLM will fill gaps
+
+---
+
+## See Also
+
+- [sims-astrology.md](../../designs/sims-astrology.md) -- The Astrillogical Effect
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) -- Full theory
+- [k-lines/](../k-lines/) -- The mechanism
+- [adversarial-committee/](../adversarial-committee/) -- Many-voiced antidote to mode-collapse
+- [yaml-jazz/](../yaml-jazz/) -- Comments as imagination seeds
+- [empathic-templates/](../empathic-templates/) -- Smart generation
+- [constructionism/](../constructionism/) -- Players build mental models
+
+---
+
+## References
+
+- **Will Wright's Stanford Lecture** (1996) -- https://donhopkins.medium.com/will-wright-on-designing-user-interfaces-to-simulation-games-1996-video-update-2023-da098a51ef91
+- **Minsky, Society of Mind** (1985) -- K-lines theory
+- **Scott McCloud, Understanding Comics** (1993) -- Masking: simple faces, detailed worlds
+- **The Sims Design Documents** -- https://donhopkins.com/home/TheSimsDesignDocuments
+
+---
+
+*"He designs games to run on two computers at once: the electronic one on the player's desk, running his shallow tame simulation, and the biological one in the player's head, running their deep wild imagination."*
+
+*The Simulator Effect is not a trick. It is how meaning works.*

--- a/skills/simulator-effect/SKILL.md
+++ b/skills/simulator-effect/SKILL.md
@@ -1,0 +1,256 @@
+# Simulator Effect Skill Specification
+
+> *Implication is more efficient (and richer) than simulation.*
+
+## Purpose
+
+The Simulator Effect skill provides principles and methods for leveraging imagination -- human or LLM -- to fill gaps in sparse specifications. Instead of exhaustive simulation, provide seeds that activate rich mental models.
+
+---
+
+## Core Methods
+
+### IMPLY
+
+Instead of simulating, imply.
+
+**Input:** Minimal specification (name, archetype, sensory details)
+**Output:** Rich interpretation filling gaps coherently
+
+```yaml
+# Input
+character:
+  archetype: "grizzled bartender"
+  
+# LLM interprets as
+bartender:
+  name: Grim
+  appearance: weathered face, salt-and-pepper beard
+  manner: laconic, speaks in short sentences
+  knowledge: has seen every adventurer who passed through
+  secrets: knows where the treasure is, will not say
+```
+
+### SEED
+
+Provide imagination seeds rather than exhaustive specification.
+
+**Seed types:**
+- **Archetype** -- "bartender", "sage", "trickster"
+- **Sensory detail** -- "smells of woodsmoke"
+- **Mystery** -- "the locked door no one mentions"
+- **Tension** -- "she avoided his gaze"
+- **K-line** -- "Sagittarius", "melancholy", "playful"
+
+```yaml
+room:
+  seeds:
+    archetype: "mysterious pub"
+    sensory: "warm despite the draft, old ale smell"
+    mystery: "the back room that requires proving yourself"
+    tension: "regulars glance at newcomers, then away"
+```
+
+### SPARSE
+
+Deliberately omit details to invite imagination.
+
+**Anti-pattern:**
+```yaml
+# Over-specified -- leaves nothing to imagine
+room:
+  name: The Rusty Lantern
+  tables: 12 oak tables, 3 round, 9 rectangular
+  chairs: 48 chairs, mix of styles
+  bar: 15 feet long, mahogany with brass rail
+  taps: 8 beer taps, 2 cider, 1 mead
+  lighting: 6 candelabras, 12 wall sconces
+  floor: wide oak planks, worn in traffic paths
+  # ... 50 more lines
+```
+
+**Pattern:**
+```yaml
+# Sparse -- imagination fills the rest
+room:
+  name: The Rusty Lantern
+  atmosphere: warm despite the draft
+  smell: woodsmoke and old ale
+  notable: the back room no one talks about
+```
+
+### ARCHETYPE
+
+Use cultural archetypes as shorthand for personality packages.
+
+**Archetype categories:**
+
+| Category | Examples | What They Activate |
+|----------|----------|-------------------|
+| Zodiac | Sagittarius, Cancer | Full personality clusters |
+| Role | Bartender, Sage, Trickster | Behavioral expectations |
+| Species | Dog, Cat, Monkey | Disposition, physicality |
+| Profession | Detective, Librarian, Chef | Knowledge, methods |
+| Trope | Grizzled veteran, Naive newcomer | Story function |
+
+```yaml
+# One word does the work of a personality matrix
+character:
+  archetype: sagittarius_explorer
+  # Implies: adventurous, philosophical, blunt, optimistic
+```
+
+### JAZZ
+
+Use YAML comments as imagination seeds (per [yaml-jazz](../yaml-jazz/)).
+
+```yaml
+playful: 9
+# not born playful -- BECAME playful by choice
+# 122 years of grim taught me joy is rebellion
+
+melancholy: 6
+# higher than I first admitted
+# the silver streaks glow when I am sad
+```
+
+Comments are read by the LLM. They shape interpretation. They are not documentation -- they are code.
+
+---
+
+## The Astrillogical Pattern
+
+Named after The Sims' zodiac implementation (1997):
+
+1. **Compute something minimal** (Euclidean distance to archetype vectors)
+2. **Display a cultural symbol** (zodiac icon)
+3. **Write no behavioral code**
+4. **Let imagination do the rest**
+
+Result: Testers reported the zodiac was "too influential" -- but there was no influence to tune. The effect was purely imagined.
+
+**Application:**
+
+```yaml
+# Minimal computation
+character:
+  personality_vector: [neat: 7, outgoing: 3, playful: 9]
+  # Display nearest archetype
+  archetype: sagittarius  # Computed, not assigned
+  
+# No behavioral code referencing 'sagittarius'
+# Player/LLM imagines Sagittarius behavior
+```
+
+---
+
+## Integration with Other Skills
+
+### With k-lines/
+
+Names activate clusters. Simulator Effect explains why.
+
+```yaml
+# K-line activation IS Simulator Effect
+character:
+  name: Palm  # Activates: open hand, tropical, reaching
+```
+
+### With adversarial-committee/
+
+Mode-collapse is Simulator Effect in reverse -- LLM collapses to mean when constraints are absent. Adversarial committee provides constraints through opposing propensities.
+
+```yaml
+committee:
+  - propensity: paranoid_realism   # Different lens
+  - propensity: idealism           # Different lens
+  - propensity: evidence_prosecutor # Different lens
+  
+# Same topic, three different Simulator Effects
+# Cross-examination finds robust interpretations
+```
+
+### With speed-of-light/
+
+One LLM call, many turns. Imagination fills the "rendering" for each turn. Sparse state, rich narrative.
+
+### With needs/
+
+Sims motives are imagination seeds, not behavior code.
+
+```yaml
+needs:
+  hunger: 30  # Seed
+  # LLM imagines: "distracted by stomach growling"
+  # Not: deterministic eat() behavior
+```
+
+### With empathic-templates/
+
+Templates leverage Simulator Effect -- provide structure, let LLM fill content.
+
+```yaml
+template: |
+  [CHARACTER] enters [ROOM] and notices [NOTABLE_DETAIL].
+  They feel [EMOTION] because [REASON].
+  
+# LLM generates coherent fill based on context
+```
+
+---
+
+## Failure Modes
+
+### Over-Specification
+
+Too much detail leaves nothing to imagine. The simulation feels mechanical.
+
+**Symptom:** Output feels like a checklist, not a story.
+**Fix:** Remove 80% of specification. Keep seeds.
+
+### Under-Seeding
+
+Not enough anchors for imagination to grip.
+
+**Symptom:** Output is generic, could be anyone/anywhere.
+**Fix:** Add archetype, sensory detail, or mystery.
+
+### Wrong Archetype
+
+Archetype conflicts with intended behavior.
+
+**Symptom:** Character behaves "off" despite correct specs.
+**Fix:** The archetype K-line is overriding your specs. Change the archetype or add explicit counters.
+
+### Mode-Collapse
+
+Single-agent LLM with weak constraints collapses to bland mean.
+
+**Symptom:** Output is safe, inoffensive, boring.
+**Fix:** Use adversarial-committee or add tension/conflict seeds.
+
+---
+
+## Metrics
+
+The Simulator Effect is working when:
+
+1. **Readers imagine more than you wrote**
+2. **LLM generates coherent detail you did not specify**
+3. **Different interpreters imagine similar worlds**
+4. **Sparse specs produce rich output**
+
+---
+
+## See Also
+
+- [k-lines/](../k-lines/) -- The mechanism
+- [yaml-jazz/](../yaml-jazz/) -- Comments as seeds
+- [adversarial-committee/](../adversarial-committee/) -- Mode-collapse antidote
+- [empathic-templates/](../empathic-templates/) -- Smart generation
+- [constructionism/](../constructionism/) -- Mental model building
+- [sims-astrology.md](../../designs/sims-astrology.md) -- The proof
+
+---
+
+*"The game provides scaffolding. Imagination does the rendering."*

--- a/skills/society-of-mind/CARD.yml
+++ b/skills/society-of-mind/CARD.yml
@@ -1,0 +1,251 @@
+# Society of Mind Skill Card
+# Intelligence emerges from the interaction of many simple agents
+
+skill:
+  id: society-of-mind
+  name: Society of Mind
+  version: 1.0.0
+  tier: core
+  entry: README.md
+  
+description: |
+  Implements Minsky's Society of Mind theory within MOOLLM.
+  Intelligence emerges from the interaction of many simple agents.
+  Skills are agents. Characters are societies. Behavior is emergent.
+  No single agent understands; understanding emerges from the pattern.
+
+# What this skill offers
+advertisement:
+  provides:
+    - agent_design: "Create minimal agents with single functions"
+    - agency_assembly: "Combine agents into emergent behaviors"
+    - competition_dynamics: "Resolve conflicts between agents"
+    - k_line_activation: "Connect symbols to agent constellations"
+    - b_brain_reflection: "Enable self-observation in characters"
+    - character_societies: "Model characters as inner societies"
+    - committee_deliberation: "Simulate deliberating agent groups"
+    
+  wants:
+    - situation: Current context for agent activation
+    - agents: List of available agents
+    - k_lines: Symbols to activate
+    
+  motives_satisfied:
+    - understanding: "How intelligence emerges"
+    - coherence: "Why behavior is consistent"
+    - realism: "Characters feel like people"
+    - robustness: "Decisions survive scrutiny"
+
+# K-lines activated by this skill
+k_lines:
+  activates:
+    - minsky: "Society of Mind author, MIT AI Lab"
+    - papert: "Collaborator, constructionism, Logo"
+    - agents: "Simple processes with single functions"
+    - agencies: "Agent clusters producing behavior"
+    - k_lines: "Activation vectors connecting to agents"
+    - frames: "Situation templates with slots"
+    - trans_frames: "Frames that transform situations"
+    - censors: "Agents preventing bad outputs"
+    - suppressors: "Agents inhibiting other agents"
+    - b_brains: "Self-observation agents"
+    - emergence: "Whole greater than parts"
+    - will_wright: "Sims as society of competing motives"
+    - autonomy_algorithm: "Score actions by motive urgency"
+    
+  connects_to:
+    - k-lines: "The memory mechanism"
+    - adversarial-committee: "Deliberating society"
+    - multi-presence: "Multiple agents active"
+    - speed-of-light: "Many agents per call"
+    - needs: "Motive agents"
+    - advertisement: "Action scoring"
+    - character: "Characters as societies"
+    - mind-mirror: "B-brain self-observation"
+    - simulator-effect: "Emergence from sparse specs"
+    - constructionism: "Learning by building societies"
+
+# Interfaces
+interfaces:
+  agent:
+    id: string          # Unique identifier
+    function: string    # What it does
+    activates_when: list[condition]
+    suppresses: list[agent_id]
+    amplifies: list[agent_id]
+    connects_to: list[agent_id]
+    knows: scope        # Usually minimal
+    
+  agency:
+    id: string
+    purpose: string
+    agents: list[agent_id]
+    coordination: string
+    emergence: string
+    
+  k_line:
+    symbol: string
+    activates: list[agent_ref]
+    
+  competition:
+    scenario: string
+    agents: list[{id, strength, votes_for, suppresses}]
+    winner: agent_id
+    consequence: string
+    
+  b_brain:
+    observes: list[agent_id]
+    reports: string
+    enables: list[capability]
+
+# Methods
+methods:
+  define_agent:
+    input: agent specification
+    output: agent definition
+    effect: agent registered in society
+    
+  assemble_agency:
+    input: list of agents, coordination rules
+    output: agency definition
+    effect: emergent behavior specified
+    
+  resolve_competition:
+    input: competing agents with strengths
+    output: winner, suppressed agents
+    effect: behavior selected
+    
+  activate_k_line:
+    input: symbol
+    output: list of activated agents
+    effect: constellation fires
+    
+  observe_society:
+    input: active agents
+    output: b_brain report
+    effect: self-awareness enabled
+
+# State
+state:
+  active_agents: list[agent_id]
+  suppressed_agents: list[agent_id]
+  agent_strengths: map[agent_id, number]
+  recent_winners: list[agent_id]
+  b_brain_observations: list[string]
+
+# Rubrics
+rubrics:
+  agent_minimality:
+    description: "Agents should do one thing"
+    criteria:
+      - single clear function
+      - limited scope of knowledge
+      - simple activation conditions
+      
+  emergent_behavior:
+    description: "Agency behavior emerges from agent competition"
+    criteria:
+      - no single agent controls
+      - behavior from interaction pattern
+      - suppressed agents remain active (but quiet)
+      
+  competition_dynamics:
+    description: "Conflict resolution is explicit"
+    criteria:
+      - strengths measured from context
+      - winner activates, loser suppresses
+      - suppressed agent grows stronger
+
+# Examples
+examples:
+  character_inner_debate:
+    description: "Palm debates whether to share his essay"
+    agents: [creative, fear, social, perfectionist]
+    resolution: "creative + social > fear + perfectionist"
+    action: "Palm shares with Don"
+    
+  multi_agent_call:
+    description: "LLM simulates inner society"
+    prompt_pattern: |
+      SITUATION: [context]
+      AGENT_1: [speaks]
+      AGENT_2: [speaks]
+      AGENT_3: [speaks]
+      Show debate. Character decides.
+      
+  sims_autonomy:
+    description: "Action selection via motive scoring"
+    algorithm: "for each action: score = sum(motive * effect)"
+    winner: "highest scoring action"
+
+# Tags
+tags:
+  - core
+  - architecture
+  - emergence
+  - agents
+  - minsky
+  - k-lines
+  - psychology
+  - character-design
+  - multi-agent
+  
+use_case: |
+  Use when designing characters with inner conflict,
+  implementing multi-agent deliberation,
+  understanding emergent behavior,
+  or building systems where intelligence emerges
+  from the interaction of simpler parts.
+
+# References
+references:
+  primary:
+    - title: "The Society of Mind"
+      author: "Marvin Minsky"
+      year: 1985
+      publisher: "Simon & Schuster"
+      isbn: "0-671-60740-5"
+      url: "https://www.societyofmind.com/"
+      
+    - title: "K-lines: A Theory of Memory"
+      author: "Marvin Minsky"
+      year: 1980
+      journal: "Cognitive Science"
+      volume: "4(2)"
+      pages: "117-133"
+      url: "https://courses.media.mit.edu/2004spring/mas966/Minsky%201980%20K-lines.pdf"
+      
+    - title: "The Emotion Machine"
+      author: "Marvin Minsky"
+      year: 2006
+      publisher: "Simon & Schuster"
+      isbn: "0-7432-7663-9"
+      
+  related:
+    - title: "Mindstorms"
+      author: "Seymour Papert"
+      year: 1980
+      publisher: "Basic Books"
+      
+    - title: "Made-Up Minds"
+      author: "Gary Drescher"
+      year: 1991
+      publisher: "MIT Press"
+      
+    - title: "Generative Agents"
+      author: "Park et al."
+      year: 2023
+      venue: "UIST"
+      arxiv: "2304.03442"
+      
+  moollm:
+    - path: "../k-lines/"
+      description: "K-lines theory"
+    - path: "../adversarial-committee/"
+      description: "Deliberating society"
+    - path: "../needs/"
+      description: "Sims motive system"
+    - path: "../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md"
+      description: "Full framework"
+    - path: "../../designs/sims-astrology.md"
+      description: "Astrillogical Effect"

--- a/skills/society-of-mind/README.md
+++ b/skills/society-of-mind/README.md
@@ -1,0 +1,555 @@
+# 🧠 Society of Mind
+
+> *"You can build a mind from many little parts, each mindless by itself."* -- Marvin Minsky
+
+> *Intelligence emerges from the interaction of many simple agents.*
+
+## MOOLLM K-Lines
+
+| K-Line | Why Related |
+|--------|-------------|
+| [moollm/](../moollm/) | MOOLLM IS a society of mind -- skills as agents |
+| [k-lines/](../k-lines/) | K-lines ARE Minsky's memory mechanism |
+| [adversarial-committee/](../adversarial-committee/) | Committee IS a society deliberating |
+| [multi-presence/](../multi-presence/) | Multiple agents active simultaneously |
+| [speed-of-light/](../speed-of-light/) | Many agents in one call |
+| [simulator-effect/](../simulator-effect/) | Imagination as emergent from agents |
+| [character/](../character/) | Characters AS agents with inner societies |
+| [persona/](../persona/) | Personas as agent overlays |
+| [mind-mirror/](../mind-mirror/) | Leary's circumplex -- personality as agent configuration |
+| [constructionism/](../constructionism/) | Papert + Minsky -- microworlds as agent playgrounds |
+| [debate/](../debate/) | Agents arguing toward wisdom |
+| [soul-chat/](../soul-chat/) | Everything speaks -- objects as agents |
+| [needs/](../needs/) | Competing motives as competing agents |
+| [leela-ai/](../leela-ai/) | Leela applies Society of Mind to manufacturing |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Reading 4: "Intelligence from agents" |
+| [MOOLLM-EVAL-INCARNATE-FRAMEWORK](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) | Full theory |
+
+**Quick Links:**
+- [Full Specification](SKILL.md) -- complete protocol
+- [Minsky's Book](https://www.societyofmind.com/) -- the source
+
+---
+
+## The Core Insight
+
+Marvin Minsky proposed that intelligence is not a single thing but an emergent property of many smaller, simpler processes -- **agents** -- working together, often in conflict.
+
+```
+    ┌───────────────────────────────────────────┐
+    │              MIND                         │
+    │  ┌─────┐  ┌─────┐  ┌─────┐  ┌─────┐       │
+    │  │Agent│  │Agent│  │Agent│  │Agent│ ...   │
+    │  │  A  │  │  B  │  │  C  │  │  D  │       │
+    │  └──┬──┘  └──┬──┘  └──┬──┘  └──┬──┘       │
+    │     │        │        │        │          │
+    │     └────────┴────────┴────────┘          │
+    │                  │                        │
+    │            ┌─────┴─────┐                  │
+    │            │  AGENCY   │                  │
+    │            │(emergent) │                  │
+    │            └───────────┘                  │
+    └───────────────────────────────────────────┘
+```
+
+No single agent "understands." Understanding emerges from the pattern of activations.
+
+---
+
+## Agents and Agencies
+
+### Agents
+
+An **agent** is a simple process with:
+- A specific function
+- Connections to other agents
+- Activation conditions
+- No understanding of the whole
+
+```yaml
+# Agent: ANGER
+anger:
+  activates_when: [blocked, threatened, betrayed]
+  suppresses: [calm, patience, forgiveness]
+  amplifies: [action, aggression, loudness]
+  duration: minutes_to_hours
+  knows: nothing about why
+```
+
+### Agencies
+
+An **agency** is a collection of agents that, together, produce behavior:
+
+```yaml
+# Agency: HUNGER
+hunger_agency:
+  agents:
+    - hunger_detector  # notices empty stomach
+    - food_memory      # recalls where food is
+    - locomotion       # moves toward food
+    - grasping         # picks up food
+    - eating           # consumes food
+    - satisfaction     # signals completion
+    
+  emergent_behavior: "seeking and eating food"
+  # No single agent knows what "hunger" means
+```
+
+---
+
+## K-Lines: The Activation Mechanism
+
+When you learn something, you form a **K-line** -- a connection that, when activated, re-activates the constellation of agents that was active during learning.
+
+```
+WHEN YOU LEARNED "GRANDMOTHER":
+  - face_recognizer was active
+  - smell_detector (cookies) was active
+  - emotion_agent (love) was active
+  - memory_agent (stories) was active
+  
+K-LINE FORMED: "grandmother"
+  
+LATER, ACTIVATING "grandmother":
+  → face_recognizer activates
+  → smell_detector activates (cookies!)
+  → emotion_agent activates (love)
+  → memory_agent activates (stories)
+```
+
+See: [k-lines/](../k-lines/) for full theory.
+
+In LLMs, tokens function as K-lines. The word "grandmother" activates associated patterns from training data.
+
+---
+
+## MOOLLM as Society of Mind
+
+MOOLLM implements Society of Mind architecture:
+
+| Minsky Concept | MOOLLM Implementation |
+|----------------|----------------------|
+| **Agents** | Skills, characters, personas |
+| **Agencies** | Skill clusters, committees |
+| **K-lines** | Skill names, PROTOCOLS.yml symbols |
+| **Frames** | YAML files as situation templates |
+| **Trans-frames** | Directory inheritance |
+| **Censors** | Ethics skills, representation-ethics |
+| **Suppressors** | Rubrics that reject bad outputs |
+| **Recognizers** | Postel-style input interpretation |
+| **Memorizers** | Session logs, persistent state |
+
+### Skills as Agents
+
+Each skill is an agent:
+
+```yaml
+# skills/bartender/ -- an agent
+bartender:
+  function: serve drinks, listen to troubles, know secrets
+  activates_when: [in pub, customer approaches, needs service]
+  connects_to: [economy, soul-chat, persona]
+  suppresses: [nothing -- bartenders hear everything]
+```
+
+When you enter the pub, the "bartender" agent activates, bringing its connections.
+
+### Committees as Agencies
+
+The [adversarial-committee](../adversarial-committee/) IS a society of mind:
+
+```yaml
+committee:
+  agents:
+    - maya:       # Paranoid realism agent
+        surfaces: hidden agendas
+    - frankie:    # Idealism agent
+        surfaces: missed opportunities
+    - vic:        # Evidence agent
+        surfaces: proof gaps
+        
+  emergent: robust_decision
+  # No single agent has the answer
+  # The debate produces wisdom
+```
+
+### Characters as Societies
+
+A character is not a single entity but a society:
+
+```yaml
+# Palm's inner society
+palm:
+  agencies:
+    - creative_drive     # wants to write
+    - social_need        # wants connection
+    - philosophical_bent # wants understanding
+    - playful_spirit     # wants humor
+    - melancholy_shadow  # remembers pain
+    
+  current_dominant: creative_drive
+  suppressed: melancholy_shadow
+  
+  # "Palm" is the emergent pattern
+  # Not any single agency
+```
+
+---
+
+## The Sims as Society of Mind
+
+Will Wright implemented Society of Mind in The Sims:
+
+```
+MOTIVES as competing agents:
+  hunger_agent: "I need food!"
+  social_agent: "I need friends!"
+  fun_agent: "I need play!"
+  energy_agent: "I need sleep!"
+  
+AUTONOMY ALGORITHM:
+  1. Each agent scores available actions
+  2. Highest total score wins
+  3. Behavior emerges from competition
+  
+No single agent controls the Sim.
+The Sim IS the competition.
+```
+
+See: [needs/](../needs/), [advertisement/](../advertisement/)
+
+The [Astrillogical Effect](../../designs/sims-astrology.md) works because the zodiac activates a K-line in the player's mind, not in the code.
+
+---
+
+## Multi-Agent LLM Patterns
+
+### Pattern 1: Adversarial Committee
+
+Simulate multiple agents with opposing propensities in one call:
+
+```yaml
+prompt: |
+  You are simulating a committee meeting.
+  
+  MAYA (paranoid realism): What are they not telling us?
+  FRANKIE (idealism): What opportunity are we missing?
+  VIC (evidence): Where is the proof?
+  
+  Topic: Should we release the new feature?
+  
+  Simulate the debate. Each agent speaks in character.
+  The decision emerges from cross-examination.
+```
+
+### Pattern 2: Inner Monologue
+
+Simulate a character's inner society:
+
+```yaml
+prompt: |
+  Palm considers whether to share his essay.
+  
+  CREATIVE DRIVE: "It is good work. Share it."
+  FEAR OF JUDGMENT: "They might not understand."
+  SOCIAL NEED: "Don gives good feedback."
+  PERFECTIONIST: "One more revision first."
+  MELANCHOLY: "Does it even matter?"
+  
+  Show the inner debate. Palm decides.
+```
+
+### Pattern 3: Speed of Light Society
+
+Many agents, one call, instant "telepathy":
+
+```yaml
+# From the 33-turn Fluxx session
+epoch:
+  - don: plays card
+  - bumblewick: reacts
+  - palm: comments
+  - maurice: narrates
+  - environment: updates
+  
+# All agents simulated in one LLM call
+# No round-trip latency
+# Instant coordination
+```
+
+See: [speed-of-light/](../speed-of-light/)
+
+---
+
+## The Papert Connection
+
+Seymour Papert was Minsky's collaborator at MIT. Together they founded the AI Lab.
+
+Papert's insight: **You learn by building societies of mind.**
+
+```
+LOGO (1967):
+  The turtle is an agent.
+  The child builds programs that coordinate turtle actions.
+  Understanding emerges from debugging.
+  
+MOOLLM (2025):
+  Skills are agents.
+  The user builds sessions that coordinate skill activations.
+  Understanding emerges from play.
+```
+
+See: [constructionism/](../constructionism/), [play-learn-lift/](../play-learn-lift/)
+
+---
+
+## Emergence vs Design
+
+Society of Mind explains why LLMs work and why they fail:
+
+### Why LLMs Work
+
+Billions of "agents" (weights, attention patterns) with no individual understanding produce emergent intelligence. No single neuron knows language; language emerges from the pattern.
+
+### Why LLMs Fail (Mode-Collapse)
+
+Single-agent inference activates the most probable pattern. The "committee" never convenes. The agents collapse to consensus before debate.
+
+**Solution:** Force the debate explicitly.
+
+```yaml
+# Bad: Ask LLM directly
+prompt: "What should we do about X?"
+
+# Good: Convene the society
+prompt: |
+  Simulate a debate:
+  - The Optimist argues for X
+  - The Pessimist argues against X
+  - The Pragmatist seeks middle ground
+  
+  Then synthesize their insights.
+```
+
+---
+
+## Minsky's Specific Concepts in MOOLLM
+
+### Frames
+
+A frame is a remembered situation structure with slots:
+
+```yaml
+# ROOM.yml IS a frame
+room:
+  name: [slot]
+  atmosphere: [slot]
+  contains: [slots...]
+  exits: [slots...]
+  
+# Fill the slots, activate the frame
+# The "room" K-line brings expectations
+```
+
+### Trans-Frames
+
+Frames that transform situations:
+
+```yaml
+# EXIT.yml IS a trans-frame
+exit:
+  from: [current room]
+  to: [destination room]
+  action: [movement verb]
+  
+# Transforms: here → there
+# Changes active frame
+```
+
+### Censors and Suppressors
+
+Agents that prevent bad activations:
+
+```yaml
+# representation-ethics/ IS a censor
+ethics:
+  censors:
+    - harmful_content
+    - deceptive_framing
+    - privacy_violations
+    
+  suppresses:
+    - actions violating consent
+    - content violating tribute protocol
+```
+
+See: [representation-ethics/](../representation-ethics/)
+
+### B-Brains (Self-Reflection)
+
+Agents that watch other agents:
+
+```yaml
+# mind-mirror/ IS a B-brain
+mind_mirror:
+  watches: [all personality agents]
+  reports: current configuration
+  enables: self-modification
+  
+# "I notice I am being defensive"
+# B-brain watching A-brain
+```
+
+See: [mind-mirror/](../mind-mirror/)
+
+---
+
+## Practical Application
+
+### Building Character Societies
+
+```yaml
+character:
+  name: Palm
+  
+  # The society
+  agents:
+    creative: {strength: 9, goal: "express"}
+    social: {strength: 8, goal: "connect"}
+    philosophical: {strength: 8, goal: "understand"}
+    playful: {strength: 9, goal: "delight"}
+    melancholy: {strength: 6, goal: "process"}
+    
+  # Agency patterns
+  when_writing: [creative, philosophical, playful]
+  when_socializing: [social, playful, creative]
+  when_alone: [philosophical, melancholy, creative]
+```
+
+### Designing Skill Agencies
+
+```yaml
+# Group skills into coherent agencies
+committee_agency:
+  purpose: "Make robust decisions"
+  skills:
+    - adversarial-committee  # The agents
+    - roberts-rules          # The protocol
+    - debate                 # The structure
+    - rubric                 # The criteria
+    - evaluator              # The judgment
+```
+
+### Debugging Emergent Behavior
+
+When behavior is wrong, ask: which agent is too strong?
+
+```yaml
+# Palm seems too serious lately
+diagnosis:
+  creative: normal
+  social: normal
+  philosophical: ELEVATED -- dominating
+  playful: SUPPRESSED -- not firing
+  melancholy: ELEVATED -- secondary
+  
+treatment:
+  - Add playful stimuli to environment
+  - Introduce humor in interactions
+  - Let playful agent win some competitions
+```
+
+---
+
+## See Also
+
+- [k-lines/](../k-lines/) -- The memory mechanism
+- [adversarial-committee/](../adversarial-committee/) -- Societies deliberating
+- [multi-presence/](../multi-presence/) -- Multiple agents active
+- [simulator-effect/](../simulator-effect/) -- Emergence from sparse specs
+- [constructionism/](../constructionism/) -- Papert's pedagogy
+- [needs/](../needs/) -- Sims motive competition
+- [mind-mirror/](../mind-mirror/) -- B-brain self-observation
+- [character/](../character/) -- Characters as societies
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) -- Full K-lines section
+
+---
+
+## References
+
+### Primary Sources
+
+- **Minsky, Marvin. *The Society of Mind*.** Simon & Schuster, 1985. ISBN 0-671-60740-5.
+  - The foundational text. 270 one-page essays building the theory.
+  - [societyofmind.com](https://www.societyofmind.com/) -- online version
+
+- **Minsky, Marvin. "K-lines: A Theory of Memory."** *Cognitive Science* 4(2), 1980, pp. 117-133.
+  - The technical paper introducing K-lines as activation vectors.
+  - [PDF](https://courses.media.mit.edu/2004spring/mas966/Minsky%201980%20K-lines.pdf)
+
+- **Minsky, Marvin. *The Emotion Machine*.** Simon & Schuster, 2006. ISBN 0-7432-7663-9.
+  - Sequel to Society of Mind, focusing on emotional agents.
+
+### Related Works
+
+- **Minsky, Marvin & Papert, Seymour. *Perceptrons*.** MIT Press, 1969 (expanded 1988).
+  - Mathematical analysis of neural networks; led to "AI Winter."
+
+- **Papert, Seymour. *Mindstorms: Children, Computers, and Powerful Ideas*.** Basic Books, 1980.
+  - Constructionism -- learning by building. Logo turtle as agent.
+
+- **Drescher, Gary. *Made-Up Minds: A Constructivist Approach to Artificial Intelligence*.** MIT Press, 1991.
+  - Schema mechanism extending Piaget with Minsky's agents.
+
+### Game Design Applications
+
+- **Wright, Will. "Stupid Fun: Thoughts on Game Design."** Stanford HCI Seminar, 1996.
+  - The Sims as society of competing motive agents.
+  - [Video](https://www.youtube.com/watch?v=pBgYKvIgXIk) (approximate)
+
+- **Wright, Will. GDC 2003 Keynote** -- "Dynamics of Game Design."
+  - Autonomy algorithm, advertisement system, emergent gameplay.
+
+### Modern LLM Applications
+
+- **Park, Joon Sung et al. "Generative Agents: Interactive Simulacra of Human Behavior."** UIST 2023.
+  - LLM agents with memory streams forming societies.
+  - [arXiv:2304.03442](https://arxiv.org/abs/2304.03442)
+
+- **Yilmaz, Baturay. "What If AI Agents Had Zodiac Personalities?"** GitHub, 2026.
+  - The experiment referenced in [sims-astrology.md](../../designs/sims-astrology.md)
+  - [github.com/baturyilmaz/what-if-ai-agents-had-zodiac-personalities](https://github.com/baturyilmaz/what-if-ai-agents-had-zodiac-personalities)
+
+---
+
+## The Lineage
+
+```
+Minsky & Papert (MIT, 1960s)
+  │
+  ├── Society of Mind (1985)
+  │     └── K-lines, agents, agencies, frames
+  │
+  ├── Logo (1967)
+  │     └── Turtle as agent, child as programmer
+  │
+  └── Constructionism (1980)
+        └── Learn by building societies
+              │
+              v
+          Will Wright (Maxis, 1989)
+              └── SimCity: agents competing for resources
+              └── The Sims: motive agents, autonomy algorithm
+                    │
+                    v
+                MOOLLM (2025)
+                    └── Skills as agents
+                    └── LLM as society of mind
+                    └── Adversarial committee as deliberation
+```
+
+---
+
+*"The question is not whether intelligent machines can have any emotions, but whether machines can be intelligent without any emotions."* -- Marvin Minsky
+
+*The agents feel nothing. The society feels everything.*

--- a/skills/society-of-mind/SKILL.md
+++ b/skills/society-of-mind/SKILL.md
@@ -1,0 +1,386 @@
+# Society of Mind Skill
+
+> *Simulate the mind as a society of agents.*
+
+## Overview
+
+This skill implements Minsky's Society of Mind theory within MOOLLM. Intelligence emerges from the interaction of many simple agents -- not from a single unified controller.
+
+## Core Mechanics
+
+### 1. Agent Definition
+
+An agent is a minimal process with:
+
+```yaml
+agent:
+  id: agent_identifier
+  function: what it does
+  activates_when: [conditions...]
+  suppresses: [other agents...]
+  amplifies: [other agents...]
+  connects_to: [related agents...]
+  knows: scope of awareness (usually minimal)
+```
+
+Agents are deliberately simple. They do one thing. They know nothing about the whole.
+
+### 2. Agency Formation
+
+Agents cluster into agencies -- groups that produce emergent behavior:
+
+```yaml
+agency:
+  id: agency_identifier
+  purpose: what emerges
+  agents: [list of agent ids]
+  coordination: how they interact
+  emergence: what behavior appears
+```
+
+### 3. K-Line Activation
+
+K-lines connect to agents. Activating a K-line activates its connected agents:
+
+```yaml
+k_line:
+  symbol: "grandmother"
+  activates:
+    - face_recognition.elderly_female
+    - olfactory.cookies
+    - emotion.love
+    - narrative.family_stories
+    - kinship.maternal_line
+```
+
+### 4. Competition and Suppression
+
+Agents compete for control. Active agents suppress competing agents:
+
+```yaml
+competition:
+  scenario: "Should I eat or socialize?"
+  
+  hunger_agency:
+    strength: 7
+    votes_for: [go_to_kitchen, find_food]
+    suppresses: [conversation, stay_here]
+    
+  social_agency:
+    strength: 8
+    votes_for: [continue_talking, stay_here]
+    suppresses: [leave, interrupt]
+    
+  winner: social_agency (strength 8 > 7)
+  behavior: continue conversation
+  consequence: hunger grows stronger
+```
+
+### 5. B-Brain Observation
+
+Higher-level agents watch lower-level agents:
+
+```yaml
+b_brain:
+  observes: [a_brain_agents...]
+  reports: current state
+  enables: self_reflection
+  
+  example:
+    a_brain: "I am getting angry"
+    b_brain: "I notice that I am getting angry"
+    c_brain: "I notice that I am noticing that I am getting angry"
+```
+
+## MOOLLM Implementation
+
+### Skills as Agents
+
+```yaml
+# Each skill directory is an agent
+skills/bartender/:
+  function: serve drinks, hear secrets
+  activates_when: in pub, customer speaks
+  connects_to: [economy, soul-chat, persona]
+  
+skills/evaluator/:
+  function: judge outputs against rubrics
+  activates_when: rubric invoked
+  suppresses: uncritical acceptance
+```
+
+### Characters as Societies
+
+```yaml
+character:
+  name: Palm
+  id: palm
+  
+  inner_society:
+    agents:
+      - {id: creative, strength: 9}
+      - {id: social, strength: 8}
+      - {id: philosophical, strength: 8}
+      - {id: playful, strength: 9}
+      - {id: melancholy, strength: 6}
+      
+    default_active: [creative, playful]
+    default_suppressed: [melancholy]
+    
+  external_presentation: emergent from agent competition
+```
+
+### Committees as Deliberating Societies
+
+```yaml
+# adversarial-committee IS a society deliberating
+committee_session:
+  agents:
+    maya:
+      propensity: paranoid_realism
+      function: surface hidden agendas
+      
+    frankie:
+      propensity: idealism  
+      function: surface missed opportunities
+      
+    vic:
+      propensity: evidence_focus
+      function: demand proof
+      
+  protocol: roberts_rules
+  emergence: robust decision surviving cross-examination
+```
+
+### Rooms as Agent Configurations
+
+```yaml
+# Entering a room activates agents
+pub_stage:
+  activates:
+    - performance_framing
+    - bartender_service
+    - audience_awareness
+    - tribute_ethics
+    
+  suppresses:
+    - private_mode
+    - unfiltered_output
+```
+
+## Protocols
+
+### Agent Instantiation Protocol
+
+When creating an agent:
+
+1. **Minimal function** -- one clear purpose
+2. **Activation conditions** -- when it fires
+3. **Connections** -- what it amplifies/suppresses
+4. **Scope awareness** -- what it knows (usually little)
+
+### Agency Assembly Protocol
+
+When assembling an agency:
+
+1. **Identify component agents**
+2. **Define coordination mechanism**
+3. **Specify emergent behavior**
+4. **Test for unintended suppression**
+
+### Competition Resolution Protocol
+
+When agents conflict:
+
+1. **Measure strengths** (from context, history, urgency)
+2. **Winner activates**, loser suppresses
+3. **Suppressed agent remains**, grows stronger over time
+4. **Eventually suppressed agent may win** (need shift)
+
+### B-Brain Integration Protocol
+
+For self-reflective characters:
+
+1. **A-brain:** Direct agents (hunger, anger, creativity)
+2. **B-brain:** Observation agents (I notice I am...)
+3. **C-brain:** Meta-observation (I notice I notice...)
+4. **Integration:** B-brain can influence A-brain
+
+## Examples
+
+### Example 1: Character Inner Conflict
+
+```yaml
+session:
+  character: Palm
+  situation: Should he publish his essay?
+  
+  agent_debate:
+    creative:
+      position: "The work is good. Share it."
+      strength: 9
+      
+    fear:
+      position: "They might judge harshly."
+      strength: 7
+      
+    social:
+      position: "Don gives good feedback."
+      strength: 8
+      
+    perfectionist:
+      position: "One more revision."
+      strength: 6
+      
+  resolution:
+    creative + social (17) > fear + perfectionist (13)
+    action: Palm shares the essay with Don
+```
+
+### Example 2: Multi-Agent LLM Call
+
+```yaml
+prompt: |
+  You are simulating Palm's inner society.
+  
+  SITUATION: Palm finds a philosophical error in his essay.
+  
+  CREATIVE AGENT: [speaks]
+  PERFECTIONIST AGENT: [speaks]
+  PHILOSOPHICAL AGENT: [speaks]
+  PLAYFUL AGENT: [speaks]
+  
+  Show their debate. Palm makes a decision.
+  
+output_format:
+  - Each agent speaks in character
+  - Conflicts are explicit
+  - Resolution emerges from debate
+  - Final action stated
+```
+
+### Example 3: Sims-Style Autonomy
+
+```yaml
+sim:
+  name: Bob
+  
+  current_motives:
+    hunger: 7/10
+    social: 4/10
+    fun: 6/10
+    energy: 5/10
+    
+  available_actions:
+    - eat_food: {hunger: +3, time: -1}
+    - call_friend: {social: +2, fun: +1, time: -1}
+    - watch_tv: {fun: +2, energy: -1, time: -2}
+    - sleep: {energy: +5, time: -8}
+    
+  autonomy_algorithm:
+    for each action:
+      score = sum(motive_weight * action_effect)
+    select: highest scoring action
+    
+  result:
+    eat_food: 7 * 3 = 21
+    call_friend: 4 * 2 + 6 * 1 = 14
+    watch_tv: 6 * 2 = 12
+    sleep: 5 * 5 = 25
+    
+    winner: sleep (highest urgency * effect)
+```
+
+## Anti-Patterns
+
+### Anti-Pattern 1: Unified Controller
+
+```yaml
+# WRONG: Single agent controls all
+character:
+  name: Palm
+  controller: central_palm_agent
+  behavior: whatever controller decides
+  
+# RIGHT: Behavior emerges from competition
+character:
+  name: Palm
+  agents: [creative, social, philosophical, playful, melancholy]
+  behavior: emergent from agent competition
+```
+
+### Anti-Pattern 2: Omniscient Agents
+
+```yaml
+# WRONG: Agent knows everything
+hunger_agent:
+  knows: all character state, world state, goals, ethics
+  
+# RIGHT: Agent knows only its domain
+hunger_agent:
+  knows: stomach emptiness, food location
+  does_not_know: social implications of eating now
+```
+
+### Anti-Pattern 3: Static Hierarchy
+
+```yaml
+# WRONG: Fixed dominance
+agents:
+  primary: rational_agent
+  secondary: emotional_agent
+  # rational always wins
+  
+# RIGHT: Dynamic competition
+agents:
+  - rational: {strength: varies_by_context}
+  - emotional: {strength: varies_by_situation}
+  # winner depends on circumstances
+```
+
+## Integration Points
+
+| Skill | Integration |
+|-------|-------------|
+| [k-lines/](../k-lines/) | Activation mechanism for agents |
+| [adversarial-committee/](../adversarial-committee/) | Deliberating society |
+| [multi-presence/](../multi-presence/) | Multiple agents in scene |
+| [speed-of-light/](../speed-of-light/) | Many agents per call |
+| [needs/](../needs/) | Motive agents competing |
+| [advertisement/](../advertisement/) | Action scoring for agents |
+| [mind-mirror/](../mind-mirror/) | B-brain observation |
+| [character/](../character/) | Characters as societies |
+| [persona/](../persona/) | Persona as agent overlay |
+| [simulator-effect/](../simulator-effect/) | Emergence from sparse agents |
+
+## References
+
+### Primary Sources
+
+- Minsky, M. (1985). *The Society of Mind*. Simon & Schuster. ISBN 0-671-60740-5.
+- Minsky, M. (1980). "K-lines: A Theory of Memory." *Cognitive Science* 4(2), 117-133. [PDF](https://courses.media.mit.edu/2004spring/mas966/Minsky%201980%20K-lines.pdf)
+- Minsky, M. (2006). *The Emotion Machine*. Simon & Schuster. ISBN 0-7432-7663-9.
+
+### Related Theory
+
+- Minsky, M. & Papert, S. (1969/1988). *Perceptrons*. MIT Press.
+- Papert, S. (1980). *Mindstorms: Children, Computers, and Powerful Ideas*. Basic Books.
+- Drescher, G. (1991). *Made-Up Minds: A Constructivist Approach to AI*. MIT Press.
+
+### Game Design
+
+- Wright, W. (1996). "Stupid Fun: Thoughts on Game Design." Stanford HCI Seminar.
+- Wright, W. (2003). "Dynamics of Game Design." GDC Keynote.
+
+### LLM Applications
+
+- Park, J.S. et al. (2023). "Generative Agents: Interactive Simulacra of Human Behavior." *UIST*. [arXiv:2304.03442](https://arxiv.org/abs/2304.03442)
+
+### MOOLLM Documentation
+
+- [k-lines/README.md](../k-lines/README.md) -- Full K-lines theory and MOOLLM implementation
+- [adversarial-committee/README.md](../adversarial-committee/README.md) -- Committee as deliberating society
+- [needs/README.md](../needs/README.md) -- Sims motive system
+- [simulator-effect/README.md](../simulator-effect/README.md) -- Implication over simulation
+- [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](../../designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980) -- K-lines section
+- [sims-astrology.md](../../designs/sims-astrology.md) -- Astrillogical Effect case study

--- a/skills/soul-chat/README.md
+++ b/skills/soul-chat/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Many-voiced IS MOOLLM |
+| [society-of-mind/](../society-of-mind/) | Objects as agents that speak |
 | [character/](../character/) | Characters speak |
 | [persona/](../persona/) | Personas give voice |
 | [room/](../room/) | Rooms can speak |

--- a/skills/speed-of-light/README.md
+++ b/skills/speed-of-light/README.md
@@ -7,6 +7,7 @@
 | K-Line | Why Related |
 |--------|-------------|
 | [moollm/](../moollm/) | Core MOOLLM principle |
+| [society-of-mind/](../society-of-mind/) | Many agents in one call (Minsky) |
 | [bootstrap/](../bootstrap/) | Speed-of-light activated on boot |
 | [simulation/](../simulation/) | Many turns in simulation |
 | [multi-presence/](../multi-presence/) | Parallel activations in one call |


### PR DESCRIPTION
## TL;DR

Add full Leela AI team + four foundational skills (Society of Mind, Simulator Effect, Manufacturing Intelligence, Leela AI) with deep cross-references throughout the codebase.

---

## 🏭 Era 25: The Full Team

> *Manufacturing Intelligence requires manufacturing intelligences.*

### New Skills (4)

| Skill | Description |
|-------|-------------|
| **society-of-mind/** | Minsky's agent theory -- intelligence emerges from many simple agents |
| **simulator-effect/** | Will Wright's insight -- implication beats simulation |
| **manufacturing-intelligence/** | Seven readings of the slogan (Papert, Minsky, Chomsky, Dweck) |
| **leela-ai/** | The company applying MOOLLM to industry |

### Leela AI Team

| Person | Role |
|--------|------|
| Henry Minsky | CTO (Marvin Minsky's son) |
| Dr. Cyrus Shaoul | Chief Evangelist |
| Dr. Milan Singh Minsky | VP Product |
| Sheung Li | VP Applications |
| Dr. Steve Kommrusch | Senior AI Research Scientist |
| Don Hopkins | AI Architect |

### Cross-References Added

Updated **21 existing skills** with two-way K-line connections:
- `k-lines/` ← society-of-mind, manufacturing-intelligence, leela-ai
- `adversarial-committee/` ← society-of-mind
- `needs/` ← society-of-mind  
- `character/` ← society-of-mind
- `constructionism/` ← society-of-mind, manufacturing-intelligence
- `representation-ethics/` ← society-of-mind, manufacturing-intelligence
- `schema-mechanism/` ← society-of-mind, leela-ai, manufacturing-intelligence
- ... and 14 more

### Design Document Updates

- `MOOLLM-MANIFESTO.md` — Minsky now links to society-of-mind skill
- `MOOLLM-EVAL-INCARNATE-FRAMEWORK.md` — Full skill link after K-lines section
- `sims-astrology.md` — Links to society-of-mind and simulator-effect
- `sims-design-index.md` — Society of Mind row added
- `sims-personality-motives.md` — Link to society-of-mind

### INDEX.yml Updates

- Added `leela-ai`, `manufacturing-intelligence`, `simulator-effect`, `society-of-mind` entries with full metadata

---

## Files Changed

- **designs/CHANGES.md** — Era 25, retrocon `e9f462a`
- **designs/*.md** — Cross-references to new skills (4 files)
- **skills/INDEX.yml** — 4 new skill entries
- **skills/README.md** — New skills in Philosophy section
- **skills/leela-ai/** — README, SKILL, CARD (new)
- **skills/manufacturing-intelligence/** — README, SKILL, CARD (new)
- **skills/simulator-effect/** — README, SKILL, CARD (new)
- **skills/society-of-mind/** — README, SKILL, CARD (new)
- **skills/**/README.md** — K-line cross-references (21 files)
- **examples/adventure-4/** — Palm MIND-MIRROR comment, k-line-connections link (2 files)

---

**42 files changed, 3,450 insertions**