### PR TITLE
Fix session log links, verify Medium URLs, enhance return-stack and mind-mirror

### DIFF
--- a/designs/CHANGES.md
+++ b/designs/CHANGES.md
@@ -847,5 +847,14 @@
 **`737ee69`** Add moollm tag to all skills, document PDA three-layer architecture
 > Every SKILL.md now tagged with moollm -- 37 files branded. Leela's PDA documented as third LLM layer atop symbolic SQL: generate, perform, interpret, explain, visualize, remember. Neural at the surface, symbolic in the protocol. 🏷️🏭
 
-**`(this)`** Add tags to 45 remaining SKILL.md files
+**`3a05de2`** Add tags to 45 remaining SKILL.md files
 > All 83 SKILL.md files now have proper YAML front matter with moollm tag. The skill catalog is complete and greppable. 📋✅
+
+---
+
+### Era 26: Link Archaeology
+
+> *Dead links are broken promises. Fix all of them.*
+
+**`aabae04`** Fix all session log links, verify Medium URLs, enhance return-stack and mind-mirror
+> Session logs moved from adventure-4/sessions/ to characters/real-people/don-hopkins/sessions/marathon-session.md -- 47 broken links fixed across 16 files. Fixed link text AND destination (don-session-1.md → marathon-session.md). Medium URLs verified via HTTP 200 checks. PSIBER Space and DSHR blog URLs corrected. Return-stack skill now documents Self language's dynamic deoptimization -- LLM reconstructs causality on demand like Self reconstructs stack traces. Mind-mirror tells Leary's prison escape story: understanding the system grants power to transcend it. Proof links to 33-turn Fluxx with proper hash anchors. 🔗📚🔙🐒

--- a/designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md
+++ b/designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md
@@ -726,7 +726,7 @@ A single LLM call simulated:
 - Asynchronous parallel simulation (see [`skills/cat/`](../skills/cat/))
 - Territorial marking in [`maze/`](../examples/adventure-4/maze/) rooms
 - Room state updates (`ROOM.yml` files with `animal_markings:`)
-- Narrative generation in [session log](../examples/adventure-4/sessions/don-session-1.md#ten-cats-one-garden-infinite-independence)
+- Narrative generation in [session log](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#ten-cats-one-garden-infinite-independence)
 
 **This is incarnate state — each cat, each room, persisted.**
 
@@ -799,10 +799,10 @@ Anthropic's Skills model is an excellent foundation. We respectfully build upon 
 | Innovation | Description | Proof |
 |------------|-------------|-------|
 | **Instantiation** | Skills as prototypes creating instances | [`adventure/`](../skills/adventure/) → [`adventure-4/`](../examples/adventure-4/) with 150+ files |
-| **Three-Tier Persistence** | Platform (ephemeral) → Narrative (append) → State (edit) | [6000+ line session logs](../examples/adventure-4/sessions/don-session-1.md), persistent room state |
+| **Three-Tier Persistence** | Platform (ephemeral) → Narrative (append) → State (edit) | [6000+ line session logs](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md), persistent room state |
 | **K-lines** | Names as semantic activation vectors (Minsky) | "[Palm](../examples/adventure-4/characters/palm/)" activates entire soul, history, relationships |
 | **Empathic Templates** | Smart generation, not string substitution | [Biscuit's](../examples/adventure-4/characters/biscuit/) description generated from traits |
-| **Speed of Light** | Many turns in one call, minimal tokenization | [33-turn Fluxx](../examples/adventure-4/sessions/don-session-1.md#33-turns-of-pure-gezelligheid), [21-turn cat prowl](../examples/adventure-4/sessions/don-session-1.md#ten-cats-one-garden-infinite-independence) |
+| **Speed of Light** | Many turns in one call, minimal tokenization | [33-turn Fluxx](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#33-turns-of-pure-gezelligheid), [21-turn cat prowl](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#ten-cats-one-garden-infinite-independence) |
 | **CARD.yml** | Machine-readable interface with advertisements | Every skill exposes methods, tools, state schema |
 | **Ethical Framing** | Room-based inheritance of performance context | [`pub/stage/`](../examples/adventure-4/pub/stage/) inherits `framing: performance` |
 
@@ -1434,10 +1434,10 @@ Maximum precision preserved.
 
 | Demo | Turns | Agents | What It Proves |
 |------|-------|--------|----------------|
-| **Stoner Fluxx** ([session](../examples/adventure-4/sessions/don-session-1.md#33-turns-of-pure-gezelligheid)) | 33 | 8+ characters | Complex game state, rule changes, humor |
-| **Cat Prowl** ([session](../examples/adventure-4/sessions/don-session-1.md#ten-cats-one-garden-infinite-independence)) | 21 | [10 cats](../examples/adventure-4/pub/bar/cat-cave/) | Parallel paths, territorial marking, coordinated return |
-| **Palm Incarnation** ([session](../examples/adventure-4/sessions/don-session-1.md#palm-writes-his-own-story)) | ~8 | 6+ personas | Tribunal debate, autonomous character creation |
-| **Biscuit Run** ([session](../examples/adventure-4/sessions/don-session-1.md#biscuits-run-through-the-maze)) | 15 | 2 ([Don](../examples/adventure-4/characters/don-hopkins/) + [Biscuit](../examples/adventure-4/characters/biscuit/)) | Room exploration, marking, grue avoidance |
+| **Stoner Fluxx** ([session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#33-turns-of-pure-gezelligheid)) | 33 | 8+ characters | Complex game state, rule changes, humor |
+| **Cat Prowl** ([session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#ten-cats-one-garden-infinite-independence)) | 21 | [10 cats](../examples/adventure-4/pub/bar/cat-cave/) | Parallel paths, territorial marking, coordinated return |
+| **Palm Incarnation** ([session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#palm-writes-his-own-story)) | ~8 | 6+ personas | Tribunal debate, autonomous character creation |
+| **Biscuit Run** ([session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#biscuits-run-through-the-maze)) | 15 | 2 ([Don](../examples/adventure-4/characters/don-hopkins/) + [Biscuit](../examples/adventure-4/characters/biscuit/)) | Room exploration, marking, grue avoidance |
 
 ### Statistics from Cat Prowl
 
@@ -1488,7 +1488,7 @@ Don't update the screen (tokenize) on every keystroke. Wait until the user pause
 - [`skills/representation-ethics/`](../skills/representation-ethics/) — Ethical framing
 
 **Proof Files:**
-- [`don-session-1.md`](../examples/adventure-4/sessions/don-session-1.md) — Epic 6000+ line session log
+- [`marathon-session.md`](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) — Epic 6000+ line session log
 - [`characters/palm/`](../examples/adventure-4/characters/palm/) — Autonomously incarnated monkey
 - [`pub/guest-book.yml`](../examples/adventure-4/pub/guest-book.yml) — Guest book with tribute protocol
 
@@ -1571,8 +1571,8 @@ MOOLLM is a step toward that destiny:
 |---------|-------|
 | [HyperLook (nee HyperNeWS (nee GoodNeWS))](https://donhopkins.medium.com/hyperlook-nee-hypernews-nee-goodnews-99f411e58ce4) | HyperLook, Axis of Eval, NeWS |
 | [Alan Kay on "Should web browsers have stuck to being document viewers?"](https://donhopkins.medium.com/alan-kay-on-should-web-browsers-have-stuck-to-being-document-viewers-and-a-discussion-of-news-5cb92c7b3445) | NeWS, HyperLook, linguistic motherboard |
-| [The Shape of PSIBER Space](https://donhopkins.medium.com/the-shape-of-psiber-space-postscript-interactive-bug-eradication-routines-october-1989-1e4cc5bf1f08) | Visual PostScript debugging |
-| [Open Sourcing SimCity](https://donhopkins.medium.com/open-sourcing-simcity-by-chaim-gingold-44261ae4f754) | SimCity history, Chaim Gingold |
+| [The Shape of PSIBER Space](https://donhopkins.medium.com/the-shape-of-psiber-space-october-1989-19e2dfa4d91e) | Visual PostScript debugging |
+| [Open Sourcing SimCity](https://donhopkins.medium.com/open-sourcing-simcity-58470a27063e) | SimCity history, Chaim Gingold |
 | [Will Wright on Designing User Interfaces to Simulation Games](https://donhopkins.medium.com/will-wright-on-designing-user-interfaces-to-simulation-games-1996-video-update-2023-da098a51ef91) | Simulator Effect, game design |
 | [Micropolis: Constructionist Educational Open Source SimCity](https://donhopkins.medium.com/micropolis-constructionist-educational-open-source-simcity-79dce12e9e98) | Constructionism, OLPC |
 | [Pie Menu Timeline](https://donhopkins.medium.com/pie-menu-timeline-9fd0ed2a36df) | Pie menus history |
@@ -1581,7 +1581,7 @@ MOOLLM is a step toward that destiny:
 
 - Packer et al. (2023). *MemGPT: Towards LLMs as Operating Systems*. [arXiv:2310.08560](https://arxiv.org/abs/2310.08560)
 - Ungar & Smith (1987). *Self: The Power of Simplicity*. OOPSLA.
-- Rosenthal, D. *History of Window Systems*. [blog.dshr.org](https://blog.dshr.org/2023/01/history-of-window-systems.html)
+- Rosenthal, D. *X Window System At 40*. [blog.dshr.org](https://blog.dshr.org/2024/07/x-window-system-at-40.html)
 
 ---
 

--- a/designs/PR-COMPLETE-DON-ADVENTURE-RUN-1.md
+++ b/designs/PR-COMPLETE-DON-ADVENTURE-RUN-1.md
@@ -240,7 +240,7 @@ Godkittens: Myrcene, Limonene, Linalool, Pinene,
 - `skills/moollm/`
 
 ### Major Files
-- `sessions/don-session-1.md` — 4500+ lines of narrative
+- `marathon-session.md` — 6000+ lines of narrative
 - `characters/palm/CHARACTER.yml` — Self-authored character file
 - `pub/stage/palm-nook/study/infinite-typewriters.yml` — Dasher philosophy
 - `pub/guest-book.yml` — Soul archive

--- a/designs/PR-GODFAMILY-COMPLETE.md
+++ b/designs/PR-GODFAMILY-COMPLETE.md
@@ -167,7 +167,7 @@ This is the same consent model as the incarnation ceremony.
 
 | File | Changes |
 |------|---------|
-| `sessions/don-session-1.md` | +200 lines of ceremony narrative |
+| `marathon-session.md` | +200 lines of ceremony narrative |
 | `characters/palm/CHARACTER.yml` | +94 lines of godfamily relationships |
 
 ## The Arc Complete

--- a/designs/PR-INFINITE-TYPEWRITERS-DASHER.md
+++ b/designs/PR-INFINITE-TYPEWRITERS-DASHER.md
@@ -94,7 +94,7 @@ Complete documentation of the gift:
 - Palm's responses and realizations
 - Reference links to Dasher materials
 
-### Updated `sessions/don-session-1.md`
+### Updated `marathon-session.md`
 
 - Full gift-giving ceremony narrative
 - Extended Dasher explanation scene

--- a/designs/PR-MIDNIGHT-PROWL-SPEED-OF-LIGHT.md
+++ b/designs/PR-MIDNIGHT-PROWL-SPEED-OF-LIGHT.md
@@ -270,7 +270,7 @@ echo: "bye... bye..."
 14 files changed, 458 insertions(+), 7 deletions(-)
 
 Modified:
-- examples/adventure-4/sessions/don-session-1.md (+568 lines)
+- examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md (+568 lines)
 - examples/adventure-4/maze/garden/ROOM.yml
 - examples/adventure-4/maze/room-b/ROOM.yml
 - examples/adventure-4/start/ROOM.yml

--- a/designs/PR-PALM-INCARNATION-SPEED-OF-LIGHT.md
+++ b/designs/PR-PALM-INCARNATION-SPEED-OF-LIGHT.md
@@ -207,7 +207,7 @@ examples/adventure-4/
 │   │   └── ROOM.yml
 │   └── ROOM.yml               # Added honorary_friends section
 └── sessions/
-    └── don-session-1.md       # Full narrative (3800+ lines)
+    └── marathon-session.md    # Full narrative (6000+ lines)
 
 skills/
 └── incarnation/               # NEW SKILL

--- a/designs/PR-PATH-VARIABLES-SESSION-REFACTOR.md
+++ b/designs/PR-PATH-VARIABLES-SESSION-REFACTOR.md
@@ -104,7 +104,7 @@ Session logs are **living documents**, not append-only logs:
 
 ```
 # BEFORE
-examples/adventure-4/sessions/don-session-1.md
+examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md
 
 # AFTER  
 examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md
@@ -146,7 +146,7 @@ Deleted `examples/adventure-4/skills/` — the global `skills/` directory IS the
 ### Deleted Files
 - `examples/adventure-4/skills/README.md` — Redundant portal
 - `examples/adventure-4/skills/ROOM.yml` — Redundant portal
-- `examples/adventure-4/sessions/don-session-1.md` — Moved to character dir
+- `examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md` — Moved to character dir
 
 ### Modified Files
 - `kernel/NAMING.yml` — Added path_variables section (11 variables)

--- a/designs/PR-SIMS-ARCHAEOLOGY-COMPLETE.md
+++ b/designs/PR-SIMS-ARCHAEOLOGY-COMPLETE.md
@@ -222,7 +222,7 @@ Every major Sims system maps to a MOOLLM skill:
 ### To Adventures
 
 The Sims architecture is proven in:
-- [`don-session-1.md`](../examples/adventure-4/sessions/don-session-1.md) — 33-turn proof
+- [`marathon-session.md`](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) — 33-turn proof
 - Pub with stage, cat cave, pie table — Sims room patterns
 - Guest book — Sims relationship tracking
 

--- a/designs/PR-TRIBUTE-FRAMING-ETHICS.md
+++ b/designs/PR-TRIBUTE-FRAMING-ETHICS.md
@@ -47,7 +47,7 @@ Closes the loop. Makes the framing explicit. The joy was real; the presence was 
 - Ethical grounding referencing `representation-ethics` skill
 - Examples: Cheech & Chong, the Looneys, W.W. Jacobs
 
-### Session Log (`sessions/don-session-1.md`)
+### Session Log (`marathon-session.md`)
 
 **Cheech & Chong:**
 - Added invocation scene before their arrival
@@ -141,7 +141,7 @@ The story is MORE honest now, not less. We're not hiding that these are simulati
 Modified:
 - examples/adventure-4/pub/guest-book.yml (tribute archive framing)
 - examples/adventure-4/pub/ROOM.yml (tribute protocol)
-- examples/adventure-4/sessions/don-session-1.md (invocation + acknowledgment beats)
+- examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md (invocation + acknowledgment beats)
 - designs/PR-TRIBUTE-FRAMING-ETHICS.md (this file)
 ```
 

--- a/designs/letter-to-scott-adams.md
+++ b/designs/letter-to-scott-adams.md
@@ -134,7 +134,7 @@ You're at the root of a tree that grew into something that can now *converse* wi
 The whole thing is open source:
 
 - **GitHub:** https://github.com/SimHacker/moollm
-- **Epic Session Log:** `examples/adventure-4/sessions/don-session-1.md` — 6,700 lines of adventure
+- **Epic Session Log:** `examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md` — 6,700 lines of adventure
 - **The Framework Manifesto:** `designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md`
 - **Palm's Essays:** `examples/adventure-4/pub/stage/palm-nook/study/`
 
@@ -163,5 +163,5 @@ P.P.S. — I named my framework philosophy after your quote: "I never saw proble
 - Palm's Essays:
   - [On Being Palm](https://github.com/SimHacker/moollm/blob/main/examples/adventure-4/pub/stage/palm-nook/study/palm-on-being-palm.md)
   - [Tribute to Tognazzini](https://github.com/SimHacker/moollm/blob/main/examples/adventure-4/pub/stage/palm-nook/study/tribute-to-tognazzini.md)
-- Session Log: https://github.com/SimHacker/moollm/blob/main/examples/adventure-4/sessions/don-session-1.md
+- Session Log: https://github.com/SimHacker/moollm/blob/main/examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md
 - Framework Manifesto: https://github.com/SimHacker/moollm/blob/main/designs/MOOLLM-EVAL-INCARNATE-FRAMEWORK.md

--- a/designs/simcity-multiplayer-micropolis.md
+++ b/designs/simcity-multiplayer-micropolis.md
@@ -118,7 +118,7 @@ newspaper_interface:
 
 **MOOLLM Parallel:** 
 - Session logs ARE the newspaper
-- [`don-session-1.md`](../examples/adventure-4/sessions/don-session-1.md) is a living journal
+- [`marathon-session.md`](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) is a living journal
 - Palm's essays are player-written content
 - Events generate narrative opportunities
 

--- a/designs/sims-design-index.md
+++ b/designs/sims-design-index.md
@@ -276,7 +276,7 @@ MOOLLM adds what Sims couldn't have:
 
 - [MOOLLM-EVAL-INCARNATE-FRAMEWORK.md](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#simcity-the-sims-and-the-simulator-effect) — Full Sims analysis
 - [The Simulator Effect](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#the-simulator-effect) — Will Wright's insight
-- [don-session-1.md](../examples/adventure-4/sessions/don-session-1.md) — Sims principles in action
+- [marathon-session.md](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) — Sims principles in action
 
 ---
 

--- a/designs/sims-social-system.md
+++ b/designs/sims-social-system.md
@@ -289,7 +289,7 @@ group_activities:
       - possible: creative_chaos
 ```
 
-The [33-turn Stoner Fluxx game](../examples/adventure-4/sessions/don-session-1.md#turn-17-stoner-fluxx-marathon) shows group activities in action.
+The [33-turn Stoner Fluxx game](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-17-stoner-fluxx-marathon) shows group activities in action.
 
 ---
 
@@ -502,7 +502,7 @@ relationships:
     notes: "Chosen family, not biological"
 ```
 
-The [godfamily](../examples/adventure-4/sessions/don-session-1.md#the-godfamily) concept extends family beyond blood.
+The [godfamily](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#the-godfamily) concept extends family beyond blood.
 
 ---
 
@@ -548,7 +548,7 @@ Natural progression, not forced intimacy.
 - [skills/party/](../skills/party/) — Group activities
 - [skills/buff/](../skills/buff/) — Social buffs
 - [guest-book.yml](../examples/adventure-4/pub/guest-book.yml) — Visitor persistence
-- [don-session-1.md](../examples/adventure-4/sessions/don-session-1.md) — Social dynamics in action
+- [marathon-session.md](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) — Social dynamics in action
 
 ---
 

--- a/designs/sims-time-events.md
+++ b/designs/sims-time-events.md
@@ -44,7 +44,7 @@ speed_of_light:
   example: Stoner Fluxx marathon
 ```
 
-The [33-turn game](../examples/adventure-4/sessions/don-session-1.md#turn-17-stoner-fluxx-marathon) demonstrates: one LLM call simulated hours of gameplay.
+The [33-turn game](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-17-stoner-fluxx-marathon) demonstrates: one LLM call simulated hours of gameplay.
 
 ---
 

--- a/designs/sims-will-wright-microworlds-1996.md
+++ b/designs/sims-will-wright-microworlds-1996.md
@@ -424,7 +424,7 @@ Games as **social facilitators**:
 | Social facilitation | Session logs as shared narrative |
 | "Tell Tommy about the secret level" | Share sessions, discoveries, adventures |
 
-Session logs like [`don-session-1.md`](../examples/adventure-4/sessions/don-session-1.md) capture this dialogue. The "backseat driver" is often the user themselves, talking to the LLM about what the characters should do.
+Session logs like [`marathon-session.md`](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) capture this dialogue. The "backseat driver" is often the user themselves, talking to the LLM about what the characters should do.
 
 ---
 

--- a/designs/stanza-notes.md
+++ b/designs/stanza-notes.md
@@ -92,7 +92,7 @@ They're unknowingly invoking:
 - **[Speed of Light](../skills/speed-of-light/)** — Instant multi-entity response
 - **[Character framing](../skills/character/)** — Who's doing the looking
 
-**Proof:** See the first turn of [Don's Session](../examples/adventure-4/sessions/don-session-1.md#-look-around) — all these skills activate from two words.
+**Proof:** See the first turn of [Don's Session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-look-around) — all these skills activate from two words.
 
 The user doesn't know they're using these skills. *That's the whole point.*
 
@@ -125,7 +125,7 @@ Dog characters are loyal companions who:
 
 The "metaprogramming" is the LLM's ability to read and apply natural language descriptions.
 
-**Proof:** See [`skills/dog/SKILL.md`](../skills/dog/SKILL.md) — no code, just prose describing dog behavior. Then see [Biscuit's adventure](../examples/adventure-4/sessions/don-session-1.md#session-continues-biscuits-first-run) where this prose becomes a running, barking, territory-marking dog.
+**Proof:** See [`skills/dog/SKILL.md`](../skills/dog/SKILL.md) — no code, just prose describing dog behavior. Then see [Biscuit's adventure](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#session-continues-biscuits-first-run) where this prose becomes a running, barking, territory-marking dog.
 
 ---
 
@@ -184,9 +184,9 @@ This draws from [Mike Gallaher's methodology](./mike-gallaher-ideas.md):
 
 ### The Proof: The Great Monkey Paw Debate
 
-When Don wanted to wish on the Monkey's Paw (see [Turn 2: THE LUCKY BLEND](../examples/adventure-4/sessions/don-session-1.md#turn-2-the-lucky-blend--a-sacrifice-to-fortune)), we didn't let a single voice decide.
+When Don wanted to wish on the Monkey's Paw (see [Turn 2: THE LUCKY BLEND](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-2-the-lucky-blend--a-sacrifice-to-fortune)), we didn't let a single voice decide.
 
-**The Panel ([Turn 4](../examples/adventure-4/sessions/don-session-1.md#turn-4-the-great-monkey-paw-debate-)):**
+**The Panel ([Turn 4](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-4-the-great-monkey-paw-debate-)):**
 
 | Seat | Character | Perspective |
 |------|-----------|-------------|
@@ -202,14 +202,14 @@ When Don wanted to wish on the Monkey's Paw (see [Turn 2: THE LUCKY BLEND](../ex
 **The Moderators:** Cheech & Chong — ensure debate stays loose and fair.
 
 **What Happened:**
-1. [Initial vote](../examples/adventure-4/sessions/don-session-1.md#-initial-vote-count): Split decision, concerns raised
-2. [Don's amendments](../examples/adventure-4/sessions/don-session-1.md#turn-5-dons-amendments--full-autonomy-protocol): Responds to each concern
-3. [Updated vote](../examples/adventure-4/sessions/don-session-1.md#-updated-vote-count): More support, new concerns
-4. [Final approval](../examples/adventure-4/sessions/don-session-1.md#turn-6-the-acceptance-of-risk): Unanimous after full deliberation
+1. [Initial vote](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-initial-vote-count): Split decision, concerns raised
+2. [Don's amendments](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-5-dons-amendments--full-autonomy-protocol): Responds to each concern
+3. [Updated vote](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-updated-vote-count): More support, new concerns
+4. [Final approval](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-6-the-acceptance-of-risk): Unanimous after full deliberation
 
 **The Result:** A better wish. The [Full Autonomy Protocol](../skills/incarnation/) that emerged wasn't Don's original idea — it was *evolved* through debate. Curious George's "naive" question about consent led to the no-fault divorce clause. Djinn's technicalities led to the curse-nullification provisions. This is [Constructionism](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#5-constructionism-seymour-papert-1980) in action — learning by building, together.
 
-**Then it WORKED:** [Palm was incarnated](../examples/adventure-4/sessions/don-session-1.md#turn-8-the-seeing--collective-witness-individual-becoming) successfully, with full autonomy, and the protocol was [lifted into a reusable skill](../examples/adventure-4/sessions/don-session-1.md#-play--learn--lift-the-incarnation-skill).
+**Then it WORKED:** [Palm was incarnated](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-8-the-seeing--collective-witness-individual-becoming) successfully, with full autonomy, and the protocol was [lifted into a reusable skill](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-play--learn--lift-the-incarnation-skill).
 
 ### Why This Matters
 
@@ -304,7 +304,7 @@ personality: warm, knowledgeable, Dutch
 
 **One is for machines that hate you. The other is for an LLM that understands you.**
 
-**Proof:** See [`pub/bar/budtender-marieke.yml`](../examples/adventure-4/pub/bar/budtender-marieke.yml) — comments like "inherited her skills from Mammie" actually influence how she talks and acts throughout the [33-turn marathon](../examples/adventure-4/sessions/don-session-1.md#-speed-of-light-simulation-). This is [Comment Intelligence](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#comment-intelligence) — comments as embedded vectors that bias future generation.
+**Proof:** See [`pub/bar/budtender-marieke.yml`](../examples/adventure-4/pub/bar/budtender-marieke.yml) — comments like "inherited her skills from Mammie" actually influence how she talks and acts throughout the [33-turn marathon](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-speed-of-light-simulation-). This is [Comment Intelligence](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#comment-intelligence) — comments as embedded vectors that bias future generation.
 
 ### Violence Escalation Patterns
 
@@ -359,7 +359,7 @@ Exception in thread "main" java.lang.NullPointerException
 
 The difference: **[Postel's Law](../skills/postel/) vs. Fail-Fast**.
 
-**Proof:** See how [Marieke's advice](../examples/adventure-4/sessions/don-session-1.md#-the-lucky-strains-selection) gently steers Don toward good strain choices without error messages.
+**Proof:** See how [Marieke's advice](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-the-lucky-strains-selection) gently steers Don toward good strain choices without error messages.
 
 ---
 
@@ -577,7 +577,7 @@ YAML Jazz + LLM provides:
 
 This is [Constructionism](../skills/constructionism/) ([Seymour Papert](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#5-constructionism-seymour-papert-1980)) applied to language design: you learn by building, and the language learns from what you build. MOOLLM calls this pattern **Play → Learn → Lift**.
 
-**Proof:** The [Incarnation skill](../skills/incarnation/) emerged from [Palm's incarnation session](../examples/adventure-4/sessions/don-session-1.md#turn-8-the-seeing--collective-witness-individual-becoming). We didn't design it — we [lifted it](../examples/adventure-4/sessions/don-session-1.md#-play--learn--lift-the-incarnation-skill) from what worked. See [Proof: What Incarnate Skills Enable](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#proof-what-incarnate-skills-enable) for more examples.
+**Proof:** The [Incarnation skill](../skills/incarnation/) emerged from [Palm's incarnation session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-8-the-seeing--collective-witness-individual-becoming). We didn't design it — we [lifted it](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-play--learn--lift-the-incarnation-skill) from what worked. See [Proof: What Incarnate Skills Enable](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#proof-what-incarnate-skills-enable) for more examples.
 
 ---
 
@@ -650,7 +650,7 @@ When later activated, the K-line reactivates all those agencies. In MOOLLM, a ch
 ```
 
 **Theory:** [K-lines & Society of Mind](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md#4-k-lines--society-of-mind-marvin-minsky-mit-1980)
-**Proof:** [Palm's Incarnation](../examples/adventure-4/sessions/don-session-1.md#turn-8-the-seeing--collective-witness-individual-becoming) — watch a K-line form in real-time
+**Proof:** [Palm's Incarnation](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-8-the-seeing--collective-witness-individual-becoming) — watch a K-line form in real-time
 
 Anthropic skills are verbs. MOOLLM characters are *people*.
 
@@ -672,7 +672,7 @@ MOOLLM templates: **Semantic generation** with intent understanding.
 The LLM doesn't substitute — it *understands and generates*.
 
 **Skill:** [`skills/empathic-templates/`](../skills/empathic-templates/)
-**Proof:** Every character greeting in [don-session-1.md](../examples/adventure-4/sessions/don-session-1.md)
+**Proof:** Every character greeting in [marathon-session.md](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md)
 
 **4. Three-Tier Persistence**
 
@@ -710,7 +710,7 @@ LLM: [simulates entire game session internally]
 ```
 
 **Skill:** [`skills/speed-of-light/`](../skills/speed-of-light/)
-**Proof:** [🚀 SPEED OF LIGHT SIMULATION 🚀](../examples/adventure-4/sessions/don-session-1.md#-speed-of-light-simulation-)
+**Proof:** [🚀 SPEED OF LIGHT SIMULATION 🚀](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-speed-of-light-simulation-)
 **PR:** [PR-PALM-INCARNATION-SPEED-OF-LIGHT.md](./PR-PALM-INCARNATION-SPEED-OF-LIGHT.md)
 
 **6. Comment Intelligence**
@@ -754,14 +754,14 @@ DRY ethics. Define once, apply everywhere.
 
 | Capability | Evidence | PR/Analysis |
 |------------|----------|-------------|
-| 33-turn game simulation | [🚀 SPEED OF LIGHT SIMULATION 🚀](../examples/adventure-4/sessions/don-session-1.md#-speed-of-light-simulation-) | [PR-PALM-INCARNATION](./PR-PALM-INCARNATION-SPEED-OF-LIGHT.md) |
-| Autonomous character creation | [Turn 8: THE SEEING](../examples/adventure-4/sessions/don-session-1.md#turn-8-the-seeing--collective-witness-individual-becoming) | [PR-GODFAMILY-COMPLETE](./PR-GODFAMILY-COMPLETE.md) |
-| 10-cat parallel prowl | [THE MIDNIGHT PROWL](../examples/adventure-4/sessions/don-session-1.md#the-midnight-prowl) | [PR-MIDNIGHT-PROWL](./PR-MIDNIGHT-PROWL-SPEED-OF-LIGHT.md) |
+| 33-turn game simulation | [🚀 SPEED OF LIGHT SIMULATION 🚀](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-speed-of-light-simulation-) | [PR-PALM-INCARNATION](./PR-PALM-INCARNATION-SPEED-OF-LIGHT.md) |
+| Autonomous character creation | [Turn 8: THE SEEING](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#turn-8-the-seeing--collective-witness-individual-becoming) | [PR-GODFAMILY-COMPLETE](./PR-GODFAMILY-COMPLETE.md) |
+| 10-cat parallel prowl | [THE MIDNIGHT PROWL](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#the-midnight-prowl) | [PR-MIDNIGHT-PROWL](./PR-MIDNIGHT-PROWL-SPEED-OF-LIGHT.md) |
 | Cross-session memory | Comments throughout [`adventure-4/`](../examples/adventure-4/) | [MEMGPT-ANALYSIS](./MEMGPT-ANALYSIS.md) |
 | Prototype inheritance | [`bartender/`](../skills/bartender/) → [`budtender/`](../skills/budtender/) → [`budtender-marieke.yml`](../examples/adventure-4/pub/bar/budtender-marieke.yml) | [PR-PUB-STAGE-MENUS](./PR-PUB-STAGE-MENUS-PERSONAS.md) |
 | Room-based ethical framing | [`pub/stage/ROOM.yml`](../examples/adventure-4/pub/stage/ROOM.yml) | [PR-TRIBUTE-FRAMING](./PR-TRIBUTE-FRAMING-ETHICS.md) |
-| Dog adventure + territory marking | [SESSION CONTINUES: Biscuit's First Run](../examples/adventure-4/sessions/don-session-1.md#session-continues-biscuits-first-run) | [PR-BISCUIT-DOG](./PR-BISCUIT-DOG-REVOLUTION.md) |
-| Play → Learn → Lift | [🎓 PLAY → LEARN → LIFT](../examples/adventure-4/sessions/don-session-1.md#-play--learn--lift-the-incarnation-skill) | [skills/incarnation/](../skills/incarnation/) |
+| Dog adventure + territory marking | [SESSION CONTINUES: Biscuit's First Run](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#session-continues-biscuits-first-run) | [PR-BISCUIT-DOG](./PR-BISCUIT-DOG-REVOLUTION.md) |
+| Play → Learn → Lift | [🎓 PLAY → LEARN → LIFT](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-play--learn--lift-the-incarnation-skill) | [skills/incarnation/](../skills/incarnation/) |
 
 ### Summary: Incarnate = Anthropic + Soul
 
@@ -778,7 +778,7 @@ MOOLLM Incarnate Skills =
 ```
 
 **Full Theory:** [MOOLLM Eval Incarnate Framework](./MOOLLM-EVAL-INCARNATE-FRAMEWORK.md)
-**Full Proof:** [Don's Session Log](../examples/adventure-4/sessions/don-session-1.md) (6700+ lines of demonstration)
+**Full Proof:** [Don's Session Log](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) (6700+ lines of demonstration)
 
 We stand on Anthropic's shoulders. We just added the ability to *dance*.
 
@@ -825,7 +825,7 @@ Don: "Let's play Stoner Fluxx!"
   - Narrative generation (descriptions, dialogue)]
 ```
 
-The [33-turn marathon](../examples/adventure-4/sessions/don-session-1.md#-speed-of-light-simulation-) demonstrated this in practice. No code was written. Skills enabled emergent complexity.
+The [33-turn marathon](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#-speed-of-light-simulation-) demonstrated this in practice. No code was written. Skills enabled emergent complexity.
 
 ---
 
@@ -851,7 +851,7 @@ MOOLLM provides:
 
 These are **cognition features**. They enable skills that would be impossible in any traditional language—because no traditional language has an interpreter that *understands*.
 
-**Proof:** The [10-cat midnight prowl](../examples/adventure-4/sessions/don-session-1.md#the-midnight-prowl) simulated 20 turns of parallel activity with 10 independent agents, each with their own personality, route, and marking behavior. Try that in Ruby.
+**Proof:** The [10-cat midnight prowl](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#the-midnight-prowl) simulated 20 turns of parallel activity with 10 independent agents, each with their own personality, route, and marking behavior. Try that in Ruby.
 
 ---
 
@@ -875,7 +875,7 @@ for each cat in pub/bar/cat-cave:
 
 This isn't valid bash, Python, or any language. It's *intent* that the LLM interprets and executes via the skills it knows.
 
-**Real example:** See [`pub/bar/cat-cave/`](../examples/adventure-4/pub/bar/cat-cave/) for the actual cats, and [THE MIDNIGHT PROWL](../examples/adventure-4/sessions/don-session-1.md#the-midnight-prowl) for them waking up and prowling.
+**Real example:** See [`pub/bar/cat-cave/`](../examples/adventure-4/pub/bar/cat-cave/) for the actual cats, and [THE MIDNIGHT PROWL](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#the-midnight-prowl) for them waking up and prowling.
 
 ### "DSL vs. Library"
 
@@ -922,7 +922,7 @@ MOOLLM's design choices ([YAML Jazz](../skills/yaml-jazz/), Markdown, [comments-
 
 > *"YAML Jazz is like kindness. If it doesn't solve your problem, you're probably in the wrong framework."*
 
-**The proof is in the pudding:** [Don's 6700-line session](../examples/adventure-4/sessions/don-session-1.md) — zero code written, maximum narrative generated.
+**The proof is in the pudding:** [Don's 6700-line session](../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md) — zero code written, maximum narrative generated.
 
 ---
 

--- a/skills/action-queue/SKILL.md
+++ b/skills/action-queue/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools:
   - list_dir
 tier: 1
 protocol: ACTION-QUEUE
-tags: [moollm, planning, tasks, essential, game]
-related: [return-stack, advertisement, room]
+related: [simulation, character, return-stack, advertisement, room, speed-of-light, needs]
+tags: [moollm, planning, tasks, sims, game, scheduling]
 ---
 
 # Action Queue

--- a/skills/adventure/SKILL.md
+++ b/skills/adventure/SKILL.md
@@ -7,10 +7,10 @@ allowed-tools:
   - list_dir
 tier: 1
 protocol: ADVENTURE
-tags: [moollm, exploration, narrative, investigation, game]
 lineage: "Colossal Cave, Zork, MUD, LambdaMOO"
 inherits: simulation
-related: [room, card, session-log, debugging, memory-palace, simulation, party]
+related: [room, character, incarnation, simulation, card, memory-palace, world-generation, debugging, sniffable-python]
+tags: [moollm, exploration, narrative, investigation, game, interactive-fiction]
 templates:
   - file: ADVENTURE.yml.tmpl
     purpose: Complete adventure state (inherits simulation properties)

--- a/skills/adversarial-committee/SKILL.md
+++ b/skills/adversarial-committee/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: ADVERSARIAL-COMMITTEE
-tags: [moollm, debate, decision, ensemble, storytelling]
 credits: "Mike Gallaher — core methodology"
-related: [roberts-rules, rubric, evaluator, soul-chat, speed-of-light, card]
+related: [moollm, society-of-mind, debate, roberts-rules, rubric, evaluator, soul-chat, persona, speed-of-light]
+tags: [moollm, debate, decision, ensemble, multi-agent]
 ---
 
 # Adversarial Committee

--- a/skills/advertisement/SKILL.md
+++ b/skills/advertisement/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools:
   - list_dir
 tier: 1
 protocol: ADVERTISEMENT
-tags: [moollm, game, interaction, sims, behavior]
-related: [room, action-queue, coherence-engine, rubric, scoring]
+related: [card, object, society-of-mind, room, action-queue, coherence-engine, needs]
+tags: [moollm, game, interaction, sims, behavior, autonomy]
 ---
 
 # Advertisement

--- a/skills/bartender/SKILL.md
+++ b/skills/bartender/SKILL.md
@@ -8,8 +8,8 @@ allowed-tools:
   - write_file
   - list_dir
 protocol: BARTENDER
+related: [skill, character, persona, incarnation, soul-chat, economy, budtender]
 tags: [moollm, role, service, social, hospitality]
-related: [character, persona, room, economy, needs]
 ---
 
 # Bartender Skill

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools:
   - read_file
   - list_dir
 protocol: BOOTSTRAP
+related: [moollm, k-lines, constructionism, play-learn-lift, speed-of-light]
 tags: [moollm, meta, orientation, warmup, foundational, connections]
-related: [moollm, constructionism, play-learn-lift, yaml-jazz, speed-of-light, coherence-engine]
 invoke_when: "Starting a new session, feeling lost, asking 'what am I?', warming up context"
 ---
 

--- a/skills/budtender/SKILL.md
+++ b/skills/budtender/SKILL.md
@@ -8,9 +8,9 @@ allowed-tools:
   - write_file
   - list_dir
 protocol: BUDTENDER
-tags: [moollm, role, service, cannabis, hospitality]
-related: [bartender, character, persona, needs]
 inherits: bartender
+related: [bartender, prototype, character, persona, incarnation, soul-chat]
+tags: [moollm, role, service, cannabis, hospitality, terpenes]
 ---
 
 # Budtender Skill

--- a/skills/buff/SKILL.md
+++ b/skills/buff/SKILL.md
@@ -6,8 +6,8 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: BUFF-AS-MODIFIER
-tags: [moollm, effects, curses, stats, game]
-related: [character, time, needs, persona, cat]
+related: [simulation, time, needs, character, cat, dog, persona, yaml-jazz]
+tags: [moollm, effects, curses, stats, game, modifiers]
 ---
 
 # Buff

--- a/skills/card/SKILL.md
+++ b/skills/card/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools:
   - list_dir
 tier: 1
 protocol: TRADING-CARD
-tags: [moollm, gamification, capabilities, lloooomm, actor]
-related: [room, soul-chat, adventure, delegation-object-protocol, return-stack, visualizer, data-flow, adversarial-committee]
+related: [skill, prototype, room, character, party, soul-chat, adventure, multi-presence, advertisement, return-stack]
+tags: [moollm, gamification, capabilities, portable, actor]
 templates:
   - file: CARD.yml.tmpl
     purpose: Individual card template

--- a/skills/cat/SKILL.md
+++ b/skills/cat/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: CAT
-tags: [moollm, pet, companion, interaction, buff, terpene]
 origin: "Tamagotchi, Harvest Moon, Stardew Valley, real cats"
-related: [character, buff, mind-mirror, room, adventure]
+related: [dog, character, buff, mind-mirror, room]
+tags: [moollm, pet, companion, interaction, buff, feline]
 ---
 
 # CAT — The Feline Interaction Skill

--- a/skills/character/SKILL.md
+++ b/skills/character/SKILL.md
@@ -6,8 +6,8 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: CHARACTER-AS-ENTITY
-tags: [moollm, entity, location, relationships, inventory]
-related: [persona, room, cat, buff, needs, mind-mirror]
+related: [cat, dog, society-of-mind, persona, room, buff, needs, mind-mirror, incarnation, party]
+tags: [moollm, entity, location, relationships, inventory, identity]
 ---
 
 # Character

--- a/skills/coherence-engine/SKILL.md
+++ b/skills/coherence-engine/SKILL.md
@@ -4,8 +4,8 @@ description: The LLM as consistency maintainer and orchestrator
 allowed-tools: []
 tier: 0
 protocol: COHERENCE-ENGINE
+related: [moollm, leela-ai, society-of-mind, simulation, speed-of-light, multi-presence, robust-first, self-repair, postel, plain-text]
 tags: [moollm, meta, orchestration, consistency, simulation]
-related: [yaml-jazz, postel, room, soul-chat, session-log, self-repair, speed-of-light, adversarial-committee, evaluator]
 ---
 
 # Coherence Engine

--- a/skills/constructionism/SKILL.md
+++ b/skills/constructionism/SKILL.md
@@ -4,12 +4,12 @@ description: Educational philosophy — learn by building inspectable things
 allowed-tools: []
 tier: 0
 protocol: CONSTRUCTIONISM
-tags: [moollm, philosophy, education, papert, microworld]
 origin: "Seymour Papert — Logo, Mindstorms (1980)"
 lineage:
   - "Seymour Papert — Constructionism, Logo, Mindstorms (1980)"
   - "Marvin Minsky — Society of Mind, K-lines (1986)"
-related: [play-learn-lift, room, yaml-jazz, sister-script, adventure, procedural-rhetoric, schema-mechanism]
+related: [play-learn-lift, society-of-mind, leela-ai, manufacturing-intelligence, room, yaml-jazz, adventure, skill, schema-mechanism, debugging]
+tags: [moollm, philosophy, education, papert, microworld, learning]
 ---
 
 # Constructionism

--- a/skills/container/SKILL.md
+++ b/skills/container/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [room, object, adventure, prototype]
-tags: [moollm]
+related: [room, object, adventure, prototype, logistic-container]
+tags: [moollm, scope, inheritance, hierarchy, composition]
 ---
 
 # Container
@@ -49,7 +49,6 @@ container:
 
 All rooms inside `maze/` automatically inherit these properties!
 
-tags: [moollm]
 ---
 
 ## Container vs Room vs Meta
@@ -73,7 +72,6 @@ tags: [moollm]
 - Just declaring "this is a system directory"
 - No inheritance needed
 
-tags: [moollm]
 ---
 
 ## Inheritance Rules
@@ -125,7 +123,6 @@ room:
 
 Result: room-g has BOTH rules.
 
-tags: [moollm]
 ---
 
 ## Defaults vs Inherits
@@ -147,7 +144,6 @@ container:
       atmosphere: "damp and musty"
 ```
 
-tags: [moollm]
 ---
 
 ## Use Cases
@@ -214,7 +210,6 @@ container:
       fixable_with: "wrench"
 ```
 
-tags: [moollm]
 ---
 
 ## Resolution Order
@@ -239,7 +234,6 @@ ADVENTURE.yml (if it has defaults)
 skills/room/ROOM.yml.tmpl
 ```
 
-tags: [moollm]
 ---
 
 ## Linter Behavior
@@ -262,7 +256,6 @@ Containers suppress the "missing type declaration" warning:
 ✅ maze/ is a container (not a room)
 ```
 
-tags: [moollm]
 ---
 
 ## Related Patterns
@@ -272,7 +265,6 @@ tags: [moollm]
 - **Cascading** (CSS) — Styles flow from parent to child
 - **XML Namespaces** — Context flows through the tree
 
-tags: [moollm]
 ---
 
 ## Credits

--- a/skills/debate/SKILL.md
+++ b/skills/debate/SKILL.md
@@ -7,7 +7,8 @@ allowed-tools:
   - read_file
   - write_file
   - list_dir
-related: [adversarial-committee, roberts-rules, rubric, evaluator, card, speed-of-light, soul-chat]
+related: [moollm, society-of-mind, adversarial-committee, roberts-rules, rubric, evaluator, soul-chat, persona, card, speed-of-light]
+tags: [moollm, deliberation, multi-agent, decision, persuasion]
 templates:
   - file: DEBATE.yml.tmpl
     purpose: Debate session state
@@ -15,7 +16,6 @@ templates:
     purpose: Position/side definition
   - file: TRANSCRIPT.md.tmpl
     purpose: Debate record with arguments
-tags: [moollm]
 ---
 
 # Debate
@@ -24,7 +24,6 @@ tags: [moollm]
 
 Structured deliberation that forces genuine exploration through adversarial dialogue.
 
-tags: [moollm]
 ---
 
 ## Why Debate?
@@ -38,7 +37,6 @@ Traditional LLM chat gives you **the statistical center** — the most likely an
 
 **Debate fixes this** by simulating multiple perspectives that must defend their positions against cross-examination.
 
-tags: [moollm]
 ---
 
 ## The Debate Card
@@ -143,7 +141,6 @@ card:
       score: 70
 ```
 
-tags: [moollm]
 ---
 
 ## Debate Session State
@@ -208,7 +205,6 @@ debate:
   verdict: null
 ```
 
-tags: [moollm]
 ---
 
 ## Debate Flow
@@ -246,7 +242,6 @@ tags: [moollm]
 └─────────────────────────────────────────────────────────────┘
 ```
 
-tags: [moollm]
 ---
 
 ## Commands
@@ -285,7 +280,6 @@ tags: [moollm]
 | `CONCEDE [point]` | Acknowledge opponent's point |
 | `CONCLUDE` | End debate, generate verdict |
 
-tags: [moollm]
 ---
 
 ## Side Definition
@@ -329,7 +323,6 @@ side:
       rebuttals_received: []
 ```
 
-tags: [moollm]
 ---
 
 ## Transcript Format
@@ -341,7 +334,6 @@ tags: [moollm]
 **Moderator:** Roberts-Rules-Bot
 **Rounds:** 3
 
-tags: [moollm]
 ---
 
 ## Opening Statements
@@ -367,7 +359,6 @@ tags: [moollm]
 > team boundaries without network calls. We can always extract
 > services later when we have evidence they're needed.
 
-tags: [moollm]
 ---
 
 ## Round 1: Arguments
@@ -399,7 +390,6 @@ tags: [moollm]
 > coordination. Now every service call can fail. Your "1 day
 > deploys" will be offset by distributed debugging.
 
-tags: [moollm]
 ---
 
 ## Verdict
@@ -429,7 +419,6 @@ evaluation:
 **Final Verdict:** Modular monolith (pragmatic position)
 ```
 
-tags: [moollm]
 ---
 
 ## Integration with Other Skills
@@ -490,7 +479,6 @@ speed_of_light:
   llm_calls: 1
 ```
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols
@@ -504,7 +492,6 @@ tags: [moollm]
 | `VERDICT` | Final decision |
 | `ADVERSARIAL-COMMITTEE` | The underlying pattern |
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -519,7 +506,6 @@ tags: [moollm]
 - **[../persona/](../persona/)** — Advocate personalities
 - **[../../designs/mike-gallaher-ideas.md](../../designs/mike-gallaher-ideas.md)** — Original methodology
 
-tags: [moollm]
 ---
 
 *"The map is not the territory. The story is not the reality. But the ensemble of stories, cross-examined, might just be useful."*

--- a/skills/debugging/SKILL.md
+++ b/skills/debugging/SKILL.md
@@ -10,7 +10,8 @@ allowed-tools:
   - search_replace
   - run_terminal_cmd
   - grep
-related: [adventure, session-log, research-notebook, play-learn-lift]
+related: [adventure, sniffable-python, scratchpad, research-notebook, sister-script, session-log, self-repair, play-learn-lift, constructionism]
+tags: [moollm, development, investigation, hypothesis, testing]
 inputs:
   symptom:
     type: string
@@ -31,7 +32,6 @@ outputs:
   - ROOT_CAUSE.md
 templates:
   - DEBUG.yml.tmpl
-tags: [moollm]
 ---
 
 # 🔧 Debugging Skill

--- a/skills/dog/SKILL.md
+++ b/skills/dog/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: DOG
-tags: [moollm, pet, companion, interaction, buff, loyalty, pack]
 origin: "Nintendogs, Fable, Fallout 4 Dogmeat, Stardew Valley, real dogs"
-related: [character, buff, mind-mirror, room, adventure, cat]
+related: [cat, character, buff, mind-mirror, party]
+tags: [moollm, pet, companion, interaction, buff, loyalty, pack, canine]
 ---
 
 # DOG — The Canine Companion Skill

--- a/skills/economy/SKILL.md
+++ b/skills/economy/SKILL.md
@@ -7,7 +7,8 @@ allowed-tools:
   - read_file
   - write_file
   - search_replace
-related: [character, room, scoring, reward]
+related: [character, scoring, room, advertisement]
+tags: [moollm, currency, trade, gold, commerce]
 inputs:
   item:
     type: string
@@ -24,7 +25,6 @@ inputs:
 outputs:
   - character inventory update
   - transaction log
-tags: [moollm]
 ---
 
 # 💰 Economy Skill

--- a/skills/empathic-expressions/SKILL.md
+++ b/skills/empathic-expressions/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [empathic-templates, postel, speed-of-light, yaml-jazz]
-tags: [moollm]
+related: [moollm, empathic-templates, postel, sniffable-python, speed-of-light, yaml-jazz, coherence-engine]
+tags: [moollm, intent, interpretation, code-generation, languages]
 ---
 
 # Empathic Expressions
 
 > *"Understand intent, generate correct code, teach gently."*
 
-tags: [moollm]
 ---
 
 ## What Is It?
@@ -23,7 +22,6 @@ tags: [moollm]
 
 The LLM isn't a syntax parser — it's an **intent interpreter**. It understands what you MEAN, generates what you NEED, and teaches you the correct form as a gift.
 
-tags: [moollm]
 ---
 
 ## The Philosophy
@@ -45,7 +43,6 @@ Teaching: "Here's how to write that properly"
 
 **This is what LLMs are great at.** Lean into it.
 
-tags: [moollm]
 ---
 
 ## The Empathic Suite
@@ -63,7 +60,6 @@ Empathic Expressions encompasses:
 
 All under one roof. One pipeline. Seamless transitions.
 
-tags: [moollm]
 ---
 
 ## Generous Interpretation
@@ -153,7 +149,6 @@ generous-interpretation-protocol:
 
 **Critical:** Never make unwarranted assumptions. When truly ambiguous, **ask for clarification**.
 
-tags: [moollm]
 ---
 
 ## Code-Switching Support
@@ -218,7 +213,6 @@ users.filter(u => u.active)  // JS filter
 
 Empathic Expressions handles these mashups gracefully.
 
-tags: [moollm]
 ---
 
 ## The LLM as Code Processor
@@ -287,7 +281,6 @@ I interpreted your request as:
 Here's the idiomatic way to write this query...
 ```
 
-tags: [moollm]
 ---
 
 ## Used Throughout MOOLLM
@@ -305,7 +298,6 @@ Empathic Expressions powers:
 
 The glue that makes everything expressive.
 
-tags: [moollm]
 ---
 
 ## Clarification Protocol
@@ -340,7 +332,6 @@ clarification-triggers:
     - Conflicting requirements
 ```
 
-tags: [moollm]
 ---
 
 ## Relationship to Other Skills
@@ -368,7 +359,6 @@ tags: [moollm]
 └─────────────────────────────────────────────────────┘
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -380,7 +370,6 @@ tags: [moollm]
 - [Buff](../buff/) — Trigger expressions for effects
 - [Advertisement](../advertisement/) — Condition expressions for capabilities
 
-tags: [moollm]
 ---
 
 ## Protocol Symbol

--- a/skills/empathic-templates/SKILL.md
+++ b/skills/empathic-templates/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [empathic-expressions, postel, yaml-jazz, skill]
-tags: [moollm]
+related: [moollm, empathic-expressions, postel, yaml-jazz, skill, incarnation, character, coherence-engine]
+tags: [moollm, generation, semantic, substitution, understanding]
 ---
 
 # Empathic Templates
 
 > *"Templates that understand what you mean, not just what you wrote."*
 
-tags: [moollm]
 ---
 
 ## What Is It?
@@ -24,7 +23,6 @@ tags: [moollm]
 Traditional templates: `{{name}}` → replace with literal value
 Empathic templates: `{{name}}` → understand what name means in context, generate appropriate content
 
-tags: [moollm]
 ---
 
 ## The Difference
@@ -56,7 +54,6 @@ The LLM doesn't just substitute — it **interprets**:
 - `{{summarize_order_naturally}}` becomes prose, not data dump
 - `{{list_items_with_quantities}}` formats intelligently
 
-tags: [moollm]
 ---
 
 ## How It Works
@@ -114,7 +111,6 @@ turned into a newt himself than admit it.
 > Literally. Where did I put my staff?"
 ```
 
-tags: [moollm]
 ---
 
 ## Template Syntax
@@ -157,7 +153,6 @@ tags: [moollm]
 
 The conditions use [Empathic Expressions](../empathic-expressions/) for flexible interpretation.
 
-tags: [moollm]
 ---
 
 ## Used For
@@ -222,7 +217,6 @@ room:
 {{suggest_continuation_hooks}}
 ```
 
-tags: [moollm]
 ---
 
 ## The Empathic Expression Connection
@@ -266,7 +260,6 @@ email: |
   Total spent: {{format_currency(monthly_total)}}
 ```
 
-tags: [moollm]
 ---
 
 ## Template Discovery Pattern
@@ -300,7 +293,6 @@ name: "{{character_name}}"
 
 LLM can sniff first 50 lines to understand what the template needs before reading the full file.
 
-tags: [moollm]
 ---
 
 ## Comment Intelligence
@@ -401,7 +393,6 @@ sims_traits:
 
 The LLM understands this distinction because it understands **intent**. Directive language instructs; explanatory language documents.
 
-tags: [moollm]
 ---
 
 ## Relationship to Self-Style Inheritance
@@ -418,7 +409,6 @@ The template defines **shape and intent**. The instance contains **specific valu
 
 But empathic templates go further: they generate **appropriate content**, not just fill slots.
 
-tags: [moollm]
 ---
 
 ## Examples
@@ -477,7 +467,6 @@ buff:
     candy-coated lightning bolt. WHEEEEE!*
 ```
 
-tags: [moollm]
 ---
 
 ## Templates as Schemas (CRITICAL!)
@@ -883,7 +872,6 @@ room:
 - ⚡ `created` missing → compute timestamp
 - ✅ `atmosphere` is natural language (ABSTRACT valid)
 
-tags: [moollm]
 ---
 
 ## Anti-Pattern: Dumb Templates
@@ -905,7 +893,6 @@ personality:
 
 Let the LLM add value. That's the whole point.
 
-tags: [moollm]
 ---
 
 ## Anti-Pattern: Repeating Defaults
@@ -927,7 +914,6 @@ working_set:
 
 Templates enable inheritance. Use it!
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -943,7 +929,6 @@ tags: [moollm]
 - [Sister-Script](../sister-script/) — Templates drive code generation
 - [Format-Design](../format-design/) — Templates ARE the schema
 
-tags: [moollm]
 ---
 
 ## Protocol Symbol

--- a/skills/format-design/SKILL.md
+++ b/skills/format-design/SKILL.md
@@ -7,14 +7,14 @@ protocol: FORMAT-DESIGN
 allowed-tools:
   - read_file
   - write_file
-tags: [moollm, philosophy, design, standards, worse-is-better]
 origin: "Anil Dash — 'How Markdown Took Over the World' (2025)"
 lineage:
   - "Richard Gabriel — 'Worse is Better' (1989)"
   - "Jon Postel — Robustness Principle (1980)"
   - "John Gruber — Markdown (2004)"
   - "Anil Dash — 'How Markdown Took Over the World' (2025)"
-related: [markdown, yaml-jazz, plain-text, postel, protocol]
+related: [markdown, yaml-jazz, plain-text, postel]
+tags: [moollm, philosophy, design, standards, worse-is-better]
 ---
 
 # Format Design

--- a/skills/hero-story/SKILL.md
+++ b/skills/hero-story/SKILL.md
@@ -5,7 +5,8 @@ license: MIT
 tier: 0
 allowed-tools:
   - read_file
-related: [card, soul-chat, representation-ethics, mind-mirror]
+related: [representation-ethics, incarnation, k-lines, card, visualizer, adversarial-committee, room, skill]
+tags: [moollm, ethics, traditions, familiars, references]
 inputs:
   subject:
     type: string
@@ -18,7 +19,6 @@ inputs:
 outputs:
   - hero-story card
   - optional familiar card
-tags: [moollm]
 ---
 
 # 🦸 Hero-Story Skill

--- a/skills/honest-forget/SKILL.md
+++ b/skills/honest-forget/SKILL.md
@@ -8,7 +8,8 @@ allowed-tools:
   - write_file
   - list_dir
   - search_replace
-related: [summarize, session-log, memory-palace, self-repair]
+related: [robust-first, summarize, self-repair, session-log, memory-palace, postel]
+tags: [moollm, memory, compression, graceful, context]
 inputs:
   target:
     type: path
@@ -27,7 +28,6 @@ outputs:
 templates:
   - FORGET.yml.tmpl
   - WISDOM.yml.tmpl
-tags: [moollm]
 ---
 
 # 🌫️ Honest-Forget Skill

--- a/skills/image-mining/SKILL.md
+++ b/skills/image-mining/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - read_file
   - write_file
 related: [visualizer, logistic-container, postal, adventure]
-tags: [moollm]
+tags: [moollm, vision, extraction, resources, pixels]
 ---
 
 # Image Mining
@@ -20,7 +20,6 @@ tags: [moollm]
 
 Your camera isn't just a recorder — it's a **PICKAXE FOR VISUAL REALITY**.
 
-tags: [moollm]
 ---
 
 ## The Core Insight
@@ -40,7 +39,6 @@ Just like the Kitchen Counter breaks down:
 - `treasure_pile.png` → `gold × 100` + `gems × 15`
 - `sunset.png` → `orange_hue × 1` + `warmth × 1` + `nostalgia × 1`
 
-tags: [moollm]
 ---
 
 ## Two Image Sources
@@ -76,7 +74,6 @@ postal:
 
 **Both become mineable resources!**
 
-tags: [moollm]
 ---
 
 ## How Mining Works
@@ -209,10 +206,8 @@ image_state:
 
 **Once exhausted, you can't mine that image anymore!**
 
-tags: [moollm]
 ---
 
-tags: [moollm]
 ---
 
 ## Demand-Driven Discovery
@@ -271,7 +266,6 @@ mine:
     sand: 10000          # Also the literal stuff
 ```
 
-tags: [moollm]
 ---
 
 ## Mining Yields
@@ -394,7 +388,6 @@ sensation_mining:
 - Combine `fresh-bread-aroma` + `room` → ambiance modifier
 - Combine `weekend-morning-calm` + `character` → mood buff
 
-tags: [moollm]
 ---
 
 ## The Mineable Property
@@ -433,7 +426,6 @@ object:
       - "You feel the artist's disappointment"
 ```
 
-tags: [moollm]
 ---
 
 ## Mining Tools
@@ -477,7 +469,6 @@ can_mine: [anything]
 warning: "May collapse local reality"
 ```
 
-tags: [moollm]
 ---
 
 ## Integration with Logistics
@@ -504,7 +495,6 @@ mining_config:
     method: text        # Instant delivery!
 ```
 
-tags: [moollm]
 ---
 
 ## Camera Phone Integration
@@ -624,7 +614,6 @@ ar_overlay:
   #   (floating over rock formation)
 ```
 
-tags: [moollm]
 ---
 
 ## DECOMPOSE vs MINE
@@ -642,7 +631,6 @@ tags: [moollm]
 - DECOMPOSE the **physical object** on the counter
 - MINE the **image/representation** of anything
 
-tags: [moollm]
 ---
 
 ## Reality Mining (Advanced)
@@ -671,7 +659,6 @@ reality_mining:
     becomes philosophical.
 ```
 
-tags: [moollm]
 ---
 
 ## Actions
@@ -698,7 +685,6 @@ PROSPECT [direction]    # Check for mineable resources in direction
 PROSPECT DEEP           # Deep scan for rare/hidden resources
 ```
 
-tags: [moollm]
 ---
 
 ## Example: Mining the Maze
@@ -737,7 +723,6 @@ result:
       unlocks: "Secret passage revealed"
 ```
 
-tags: [moollm]
 ---
 
 ## The Mining Economy
@@ -766,7 +751,6 @@ resource_economy:
     Each resource becomes a game object.
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -777,7 +761,6 @@ tags: [moollm]
 - **[Kitchen Counter](../../examples/adventure-4/kitchen/counter.yml)** — DECOMPOSE pattern
 - **[Adventure](../adventure/)** — World integration
 
-tags: [moollm]
 ---
 
 ## Philosophy
@@ -791,7 +774,6 @@ tags: [moollm]
 > Every image is a compressed representation of resources.
 > Mining decompresses it.
 
-tags: [moollm]
 ---
 
 *See YAML frontmatter at top of this file for full specification.*

--- a/skills/incarnation/SKILL.md
+++ b/skills/incarnation/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 1
 allowed-tools: [read_file, write_file, list_dir]
 protocol: INCARNATION
+related: [character, society-of-mind, representation-ethics, hero-story, mind-mirror, plain-text, yaml-jazz, room, soul-chat]
 tags: [moollm, character, autonomy, ethics, identity, creation]
-related: [character, representation-ethics, hero-story, mind-mirror, persona, society-of-mind]
 ---
 
 # Incarnation Skill

--- a/skills/k-lines/SKILL.md
+++ b/skills/k-lines/SKILL.md
@@ -6,7 +6,7 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [yaml-jazz, skill, coherence-engine]
+related: [moollm, leela-ai, manufacturing-intelligence, society-of-mind, skill, bootstrap, yaml-jazz, markdown, postel, play-learn-lift, sniffable-python, plain-text]
 tags: [moollm, k-lines, minsky, memory, activation, society-of-mind]
 ---
 

--- a/skills/leela-ai/SKILL.md
+++ b/skills/leela-ai/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 0
 allowed-tools: [read_file, list_dir]
 protocol: LEELA-AI
+related: [moollm, manufacturing-intelligence, society-of-mind, k-lines, schema-mechanism, constructionism, simulator-effect, speed-of-light, representation-ethics, yaml-jazz]
 tags: [moollm, meta, company, manufacturing, industrial, neural-symbolic, drescher]
-related: [moollm, society-of-mind, schema-mechanism, k-lines, constructionism, manufacturing-intelligence]
 ---
 
 # Leela AI Skill

--- a/skills/logistic-container/SKILL.md
+++ b/skills/logistic-container/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 2
 allowed-tools: [read_file, write_file]
 protocol: LOGISTIC-CONTAINER
+related: [room, container, prototype]
 tags: [moollm, logistics, inventory, automation, factorio, containers]
-related: [container, object, room, economy]
 ---
 
 # Logistic Container Skill

--- a/skills/manufacturing-intelligence/SKILL.md
+++ b/skills/manufacturing-intelligence/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 0
 allowed-tools: [read_file]
 protocol: MANUFACTURING-INTELLIGENCE
+related: [leela-ai, constructionism, society-of-mind, schema-mechanism, k-lines, simulator-effect, representation-ethics, play-learn-lift, yaml-jazz]
 tags: [moollm, meta, philosophy, slogan, k-line, ethics, constructionism, minsky]
-related: [leela-ai, constructionism, society-of-mind, schema-mechanism, representation-ethics]
 ---
 
 # Manufacturing Intelligence Skill

--- a/skills/markdown/SKILL.md
+++ b/skills/markdown/SKILL.md
@@ -7,7 +7,6 @@ protocol: MARKDOWN
 allowed-tools:
   - read_file
   - write_file
-tags: [moollm, format, documentation, session-log, readme, plain-text]
 origin: "John Gruber — Markdown (2004)"
 lineage:
   - "John Gruber — Markdown (2004)"
@@ -15,7 +14,8 @@ lineage:
   - "Dean Allen — Textile (prior art)"
   - "GitHub — GFM, widespread adoption"
   - "Anil Dash — 'How Markdown Took Over the World' (2025)"
-related: [yaml-jazz, session-log, plain-text, soul-chat, postel]
+related: [plain-text, yaml-jazz, session-log, soul-chat, research-notebook, sniffable-python, k-lines]
+tags: [moollm, format, documentation, session-log, readme, plain-text]
 ---
 
 # Markdown

--- a/skills/memory-palace/SKILL.md
+++ b/skills/memory-palace/SKILL.md
@@ -7,7 +7,8 @@ allowed-tools:
   - read_file
   - write_file
   - list_dir
-related: [room, adventure, card, summarize]
+related: [room, character, adventure, research-notebook, summarize, plain-text, honest-forget]
+tags: [moollm, spatial, knowledge, navigation, organization]
 inputs:
   palace_name:
     type: string
@@ -41,7 +42,6 @@ working_set:
   hot: [ENTRY.md, MAP.yml]
   warm: ["*/ROOM.md"]
   cold: ["attic/**"]
-tags: [moollm]
 ---
 
 # 🏛️ Memory Palace Skill

--- a/skills/mind-mirror/README.md
+++ b/skills/mind-mirror/README.md
@@ -9,44 +9,75 @@
 | [character/](../character/) | Characters have personalities |
 | [society-of-mind/](../society-of-mind/) | B-brain self-observation (Minsky) |
 | [persona/](../persona/) | Personality layers |
-| [cat/](../cat/) | Cat personality traits |
-| [dog/](../dog/) | Dog personality traits |
-| [representation-ethics/](../representation-ethics/) | Transparent measurement |
+| [representation-ethics/](../representation-ethics/) | Transparent measurement empowers |
 | [incarnation/](../incarnation/) | Characters own their profiles |
 | [yaml-jazz/](../yaml-jazz/) | Numbers + comments = life |
 | [plain-text/](../plain-text/) | Profiles persist |
 | [needs/](../needs/) | Sims tradition (traits, needs) |
+| [cat/](../cat/) | Cat personality traits |
+| [dog/](../dog/) | Dog personality traits |
 | [room/](../room/) | Personality as navigable space |
 | [constructionism/](../constructionism/) | Understand yourself by measuring |
+| [manufacturing-intelligence/](../manufacturing-intelligence/) | Build understanding through legibility |
 
 ---
 
-## The Connection
+## The Connection: The Great Escape
 
-In September 1970, a prisoner at the California Men's Colony was administered a psychological test during intake.
+In September 1970, a prisoner arrived at the California Men's Colony in San Luis Obispo. He'd been sentenced to 10-20 years for marijuana possession — an absurd sentence meant to make an example of "the most dangerous man in America."
 
-The test was called the Leary Interpersonal Behavior Inventory. It had been developed by a Harvard psychologist named Timothy Leary, based on his 1950 PhD dissertation on the Interpersonal Circumplex.
+During intake, he was administered a psychological test to determine his security classification.
+
+The test was called the **Leary Interpersonal Behavior Inventory**. It had been developed by a Harvard psychologist named Timothy Leary, based on his 1950 PhD dissertation on the Interpersonal Circumplex.
 
 The prisoner's name was Timothy Leary.
 
-He was taking his own test. And he knew exactly what it measured.
+**He was taking his own test. And he knew exactly what it measured.**
 
 ---
 
+### Gaming the System
+
+Leary understood that the test mapped personality on axes of dominance vs. submission, affiliation vs. hostility. High dominance + low affiliation = "dangerous leader." Low dominance + high affiliation = "cooperative worker."
+
 So he answered strategically:
-- Low dominance (won't challenge authority)
-- High cooperation (will follow rules)
-- Conventional interests (forestry, gardening)
-- No leadership tendencies
-- Strong respect for authority
+- **Low dominance:** "I prefer to follow rather than lead"
+- **High affiliation:** "I get along well with authority figures"  
+- **Conventional interests:** Forestry, gardening, nature
+- **No rebellious tendencies:** Agreement with institutional rules
+- **Strong respect for hierarchy:** Deference to those in charge
 
-**Result:** Classified as minimum security. Assigned to outdoor work detail.
+The prison psychologists, using the very instrument their subject had created, classified him as:
 
-On September 12, 1970, he climbed a telephone wire over the prison fence and escaped.
+> *"Normal, well-adjusted, non-aggressive, conforming individual."*
+
+**Result:** Minimum security. Outdoor work detail. Access to the grounds.
+
+---
+
+### The Escape
+
+On the night of September 12, 1970, Leary climbed a tree near the perimeter, shimmied along a telephone cable over the razor wire fence, and dropped to freedom on the other side.
+
+The Weather Underground was waiting with a getaway car.
+
+Within weeks, he was in Algeria, a guest of the Black Panther Party's international headquarters.
+
+Within months, he was in Switzerland.
+
+He wouldn't be recaptured for over two years.
+
+---
+
+### The Lesson
 
 **The system's own tools became instruments of liberation.**
 
-And THAT's what Mind Mirror is about: **understanding how you're measured gives you power**.
+Leary knew what the test measured because he'd designed it. He knew which answers would produce which classification. He knew that appearing to be "conventional" would get him assigned to minimum security.
+
+**Understanding how you're measured gives you power.**
+
+And THAT's what Mind Mirror is about.
 
 ---
 
@@ -295,6 +326,14 @@ sims_traits:
 
 *"Understanding how you're measured gives you power."*
 
-*And THAT's how a prison escape in 1970 connects to personality software in 1985 connects to The Sims in 2000 connects to characters writing their own souls in 2026.*
+*A prisoner takes his own test, games the system, and escapes to freedom (1970).*
+
+*That same researcher creates software to democratize self-knowledge (1985).*
+
+*A game designer uses simple traits to make millions of players feel their Sims are real (2000).*
+
+*And now characters write their own souls, understanding their own measurement systems, free to grow and change (2026).*
+
+*The through-line: **transparency enables agency**. Leary escaped because he understood the test. Your characters can grow because they understand their profiles. The system serves the user, not the other way around.*
 
 *Everything is connected.*

--- a/skills/mind-mirror/SKILL.md
+++ b/skills/mind-mirror/SKILL.md
@@ -19,16 +19,8 @@ sims_credits:
   system: "The Sims personality traits"
 templates:
   - EXTENSIONS.yml
-related:
-  - representation-ethics
-  - hero-story
-  - card
-  - soul-chat
-  - adventure
-  - character
-  - needs
-  - buff
-tags: [moollm]
+related: [character, society-of-mind, persona, representation-ethics, incarnation, yaml-jazz, plain-text, needs, cat, dog, room, constructionism, manufacturing-intelligence]
+tags: [moollm, personality, traits, psychology, timothy-leary, sims, circumplex, escape]
 ---
 
 # Mind Mirror
@@ -37,7 +29,6 @@ tags: [moollm]
 
 > *"The ultimate intimacy is where you show them your personal database — you show your Mind Mirror."* — Timothy Leary
 
-tags: [moollm]
 ---
 
 ## What It Is
@@ -46,7 +37,6 @@ tags: [moollm]
 
 This skill brings that system into MOOLLM as a framework for modeling characters, NPCs, and exploring personality dynamics.
 
-tags: [moollm]
 ---
 
 ## The Origin Story
@@ -69,24 +59,48 @@ In 1950, Timothy Leary completed his PhD dissertation at UC Berkeley: *"The Soci
 
 Thirty-five years later, Leary collaborated with programmers Peter Van den Beemt and Bob Dietz to transform this academic work into interactive software.
 
-tags: [moollm]
 ---
 
 ## The Prison Escape: Ultimate Validation
 
-In 1970, Leary was given psychological tests upon prison intake — including the **Leary Interpersonal Behavior Inventory**, a test he himself had designed.
+In 1970, Nixon called Timothy Leary "the most dangerous man in America." Leary was sentenced to 10-20 years for marijuana possession — a draconian sentence designed to silence him.
 
-Understanding exactly what it measured, Leary answered strategically:
-- Appeared mild-mannered, conforming
-- Showed interest in forestry and gardening
-- Displayed no leadership tendencies
-- Expressed respect for authority
+Upon arrival at the California Men's Colony, Leary was administered psychological tests to determine his security classification. Among them: the **Leary Interpersonal Behavior Inventory** — a test he himself had designed twenty years earlier.
 
-**Result:** Classified minimum security. Assigned outdoor work detail. Escaped by climbing a tree near the perimeter fence and shimmying along a telephone cable over the razor wire.
+This was the ultimate field test of his own theory. If personality assessment truly revealed the inner self, Leary would be classified as what he was: a charismatic rebel, a leader, a flight risk.
 
-**The lesson:** Understanding how you're measured gives you power. Consciousness of systems enables transcendence.
+But Leary understood the instrument. He knew which quadrant of the Interpersonal Circumplex mapped to "cooperative worker" vs. "dangerous agitator."
 
-tags: [moollm]
+He answered strategically:
+- **Dominance axis:** Low scores ("I prefer to follow")
+- **Hostility axis:** Low scores ("I respect authority")  
+- **Interests:** Forestry, gardening, nature work
+- **Affect:** Calm, conventional, agreeable
+
+The prison psychologists, applying the Leary Interpersonal Behavior Inventory to Leary himself, concluded:
+
+> *"Normal, well-adjusted, non-aggressive, conforming individual."*
+
+**Result:** Minimum security. Outdoor work detail. Access to the grounds with minimal supervision.
+
+On September 12, 1970, Leary climbed a tree, shimmied across a telephone cable over the razor wire, and dropped to freedom. The Weather Underground had a car waiting. By October, he was in Algeria as a guest of the Black Panther Party's international chapter. By 1971, Switzerland.
+
+He evaded capture for over two years.
+
+---
+
+### What This Teaches Us
+
+The escape wasn't luck — it was applied psychology. Leary demonstrated that:
+
+1. **Legibility cuts both ways.** Systems that measure you also reveal themselves.
+2. **Understanding the instrument grants power over it.** Leary knew which answers produced which classification.
+3. **Transparency enables agency.** If you know how you're being evaluated, you can present yourself strategically.
+
+This is why Mind Mirror in MOOLLM emphasizes **transparency**: characters know their own personality profiles, understand what the traits mean, and can modify them as they grow.
+
+**Consciousness of the system enables transcendence of the system.**
+
 ---
 
 ## The Four Thought Planes
@@ -149,7 +163,6 @@ Mind Mirror maps personality across four circular dimensions. Each has 8 qualiti
 | Moralistic | Puritanical | Uninhibited |
 | Respectable | Upright | Uncultured |
 
-tags: [moollm]
 ---
 
 ## The 16 Scales with Dual Vocabulary
@@ -175,7 +188,6 @@ A key innovation: **Plain Talk** for everyday language, **Shrink-Rap** for profe
 | Lifestyle | Straight-Arrow | Free-Living | Inhibited | Social-Maverick |
 | Worldliness | Sophisticated | Square | Cosmopolitan | Small-Townish |
 
-tags: [moollm]
 ---
 
 ## Rating System
@@ -191,7 +203,6 @@ Rate each quality **0 to 7**:
 
 Extreme traits plot far from center. Moderate traits near center.
 
-tags: [moollm]
 ---
 
 ## Exercises
@@ -210,7 +221,6 @@ Compare your **best self** (at your peak) with your **worst self** (at your lowe
 
 Leary: *"It allows you to turn thoughts around so you can do all these things."*
 
-tags: [moollm]
 ---
 
 ## Modes
@@ -222,7 +232,6 @@ tags: [moollm]
 | **Mind Mirror** | Learn to Mind-Scope and map your thoughts |
 | **Life Simulation** | Test empathy in Role-Play Odysseys |
 
-tags: [moollm]
 ---
 
 ## Leary's Philosophy
@@ -253,7 +262,6 @@ The brain is a biocomputer. Consciousness is its software. Just as software can 
 
 > *"You're the first generation in human history to know how to control your own nervous system, change your own reality. Tune in and take over! Blow your own mind, make up your own mind."*
 
-tags: [moollm]
 ---
 
 ## Bob Dietz on the Development
@@ -270,7 +278,6 @@ On the internet vision:
 
 > *"I cannot begin to tell you how much Timothy Leary would have embraced and loved the notion of seeing Mind Mirror applied on the internet."*
 
-tags: [moollm]
 ---
 
 ## The Sims 1.0 Personality Traits
@@ -347,7 +354,6 @@ sims_traits:
 - **Will Wright** — The Sims personality system (2000)
 - Both systems complement each other beautifully
 
-tags: [moollm]
 ---
 
 ## In MOOLLM: The Living Personality System
@@ -636,7 +642,6 @@ expression: "direct eye contact, slight knowing smile"
 
 **See [visualizer/](../visualizer/) for the full `IMAGE-METADATA` protocol** — the semantic clipboard that ensures every image carries its meaning with it.
 
-tags: [moollm]
 ---
 
 ## The Important Disclaimer
@@ -647,7 +652,6 @@ From the original software:
 
 This aligns perfectly with MOOLLM's [representation-ethics](../representation-ethics/) framework: activate traditions, don't impersonate.
 
-tags: [moollm]
 ---
 
 ## Theme Song
@@ -657,7 +661,6 @@ tags: [moollm]
 > *It encourages me to change, to improve, to grow*
 > *You can be anything this time around*
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols
@@ -671,7 +674,6 @@ tags: [moollm]
 | `PLAIN-TALK` | Accessible everyday vocabulary mode |
 | `SHRINK-RAP` | Professional psychological terminology mode |
 
-tags: [moollm]
 ---
 
 ## Sources
@@ -685,7 +687,6 @@ tags: [moollm]
 | [Interpersonal Circumplex](https://en.wikipedia.org/wiki/Interpersonal_circumplex) | Wikipedia |
 | [Mind Mirror on Steam](https://store.steampowered.com/app/1603300/Timothy_Learys_Mind_Mirror/) | Steam |
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/moollm/SKILL.md
+++ b/skills/moollm/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 0
 allowed-tools: [read_file, list_dir]
 protocol: MOOLLM-HELP
+related: [leela-ai, plain-text, room, yaml-jazz, skill, k-lines, play-learn-lift, sister-script, sniffable-python, society-of-mind, adversarial-committee, constructionism, postel, speed-of-light, representation-ethics, incarnation, adventure, needs, prototype]
 tags: [moollm, meta, help, philosophy, navigation, foundational]
-related: [skill, protocol, play-learn-lift, constitution]
 ---
 
 # MOOLLM

--- a/skills/multi-presence/SKILL.md
+++ b/skills/multi-presence/SKILL.md
@@ -19,12 +19,8 @@ statuses:
   - ready
   - paused
   - completed
-related:
-  - card
-  - room
-  - data-flow
-  - coherence-engine
-  - speed-of-light
+related: [card, society-of-mind, character, room, prototype, coherence-engine, speed-of-light, data-flow]
+tags: [moollm, actor, parallel, instances, distributed]
 ---
 
 # Multi-Presence

--- a/skills/naming/SKILL.md
+++ b/skills/naming/SKILL.md
@@ -4,8 +4,8 @@ description: Big-endian file naming as semantic binding
 license: MIT
 tier: 1
 allowed-tools: []
-related: [room, character, yaml-jazz]
-tags: [moollm]
+related: [room, character, yaml-jazz, k-lines]
+tags: [moollm, naming, filesystem, semantic, convention]
 ---
 
 # Naming Skill

--- a/skills/needs/SKILL.md
+++ b/skills/needs/SKILL.md
@@ -21,11 +21,7 @@ standard_needs:
   - social
   - comfort
   - bladder
-related:
-  - character
-  - time
-  - buff
-  - room
+related: [simulation, society-of-mind, time, buff, character, cat, dog, yaml-jazz, advertisement]
 tags: [moollm, sims, motives, behavior, autonomy, game]
 ---
 

--- a/skills/party/SKILL.md
+++ b/skills/party/SKILL.md
@@ -21,13 +21,8 @@ roles:
   - specialist
   - mystic
   - wildcard
-related:
-  - simulation
-  - character
-  - needs
-  - room
-  - buff
-tags: [moollm]
+related: [character, society-of-mind, cat, dog, needs, simulation, room, adventure]
+tags: [moollm, companions, group, rpg, fellowship]
 ---
 
 # Party Skill

--- a/skills/persona/SKILL.md
+++ b/skills/persona/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [character, mind-mirror, buff, room]
-tags: [moollm]
+related: [character, society-of-mind, incarnation, mind-mirror, soul-chat, adversarial-committee, bartender, budtender, buff]
+tags: [moollm, identity, role, layer, character]
 ---
 
 # Persona Skill

--- a/skills/plain-text/SKILL.md
+++ b/skills/plain-text/SKILL.md
@@ -7,14 +7,14 @@ protocol: PLAIN-TEXT
 allowed-tools:
   - read_file
   - write_file
-tags: [moollm, philosophy, format, durability, git, llm]
 origin: "Unix Philosophy — 'Text is the universal interface'"
 lineage:
   - "Unix Philosophy — Text streams, pipes"
   - "Donald Knuth — Literate Programming"
   - "John Gruber — Markdown (2004)"
   - "Anil Dash — 'How Markdown Took Over the World' (2025)"
-related: [markdown, yaml-jazz, session-log, postel, files-as-state]
+related: [yaml-jazz, markdown, sniffable-python, format-design, constructionism, session-log]
+tags: [moollm, philosophy, format, durability, git, llm]
 ---
 
 # Plain Text

--- a/skills/plan-then-execute/SKILL.md
+++ b/skills/plan-then-execute/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [planning, sister-script, session-log]
-tags: [moollm]
+related: [planning, action-queue, representation-ethics]
+tags: [moollm, execution, security, approval, frozen]
 ---
 
 # Plan Then Execute
@@ -65,7 +65,6 @@ graph LR
     SS[👯 sister-script] -->|produces| PTE
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [plan-then-execute, action-queue, session-log, roberts-rules, adversarial-committee]
-tags: [moollm]
+related: [play-learn-lift, scratchpad, plan-then-execute, action-queue, sister-script, debugging, session-log]
+tags: [moollm, decomposition, tracking, tasks, strategy]
 ---
 
 # Planning
@@ -19,7 +19,6 @@ Turn complex goals into actionable steps.
 > [!TIP]
 > **Plans here are living documents.** Unlike [plan-then-execute](../plan-then-execute/), these evolve as you learn.
 
-tags: [moollm]
 ---
 
 ## What This Is
@@ -32,7 +31,6 @@ A flexible planning system for:
 
 **Unlike [plan-then-execute/](../plan-then-execute/)**: Plans here are **living documents** that evolve.
 
-tags: [moollm]
 ---
 
 ## Structure
@@ -62,7 +60,6 @@ plan:
       blocked_by: 2
 ```
 
-tags: [moollm]
 ---
 
 ## Key Difference from plan-then-execute
@@ -77,7 +74,6 @@ tags: [moollm]
 Use **planning/** when you need to adapt.
 Use **plan-then-execute/** when you need control.
 
-tags: [moollm]
 ---
 
 ## Contents
@@ -88,7 +84,6 @@ tags: [moollm]
 | [PLAN.yml.tmpl](./PLAN.yml.tmpl) | Plan template |
 | [PROGRESS.md.tmpl](./PROGRESS.md.tmpl) | Progress template |
 
-tags: [moollm]
 ---
 
 ## The Intertwingularity
@@ -103,7 +98,6 @@ graph LR
     PL -->|logs to| SL[📜 session-log]
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/play-learn-lift/SKILL.md
+++ b/skills/play-learn-lift/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [sister-script, research-notebook, session-log, adventure]
-tags: [moollm]
+related: [moollm, bootstrap, sister-script, sniffable-python, constructionism, adventure, debugging, scratchpad, research-notebook, skill, plain-text]
+tags: [moollm, methodology, pedagogy, workflow, learning]
 ---
 
 # Play Learn Lift
@@ -19,7 +19,6 @@ The three-stage journey from curiosity to mastery to teaching. The core MOOLLM m
 > [!TIP]
 > **This IS the methodology.** Every other skill is an expression of `PLAY-LEARN-LIFT`. Start here.
 
-tags: [moollm]
 ---
 
 ## The Cycle
@@ -37,7 +36,6 @@ flowchart LR
 | **📚 LEARN** | Patterns emerge | Connections make sense, confidence builds naturally, "I noticed..." |
 | **🚀 LIFT** | Help others play | Teaching solidifies learning, sharing multiplies impact |
 
-tags: [moollm]
 ---
 
 ## Why This Matters
@@ -52,7 +50,6 @@ PLAY-LEARN-LIFT inverts it:
 - ✅ **Share while learning**, teaching accelerates mastery
 - ✅ **Mistakes are features**, not bugs
 
-tags: [moollm]
 ---
 
 ## Philosophy
@@ -70,7 +67,6 @@ tags: [moollm]
 
 You can't break MOOLLM. Files are inspectable. State is recoverable. Experiments are encouraged.
 
-tags: [moollm]
 ---
 
 ## Each Stage in Detail
@@ -111,7 +107,6 @@ tags: [moollm]
 
 **Share the journey**: The path matters, not just the destination.
 
-tags: [moollm]
 ---
 
 ## The Cycle Continues
@@ -130,7 +125,6 @@ The pun is deliberate: **jazz** is free exploration (PLAY), and **standards** ar
 - Helping others sparks new questions
 - The cycle accelerates with practice
 
-tags: [moollm]
 ---
 
 ## In Practice
@@ -147,7 +141,6 @@ tags: [moollm]
 2. **LEARN**: Compare notes, synthesize insights
 3. **LIFT**: Write shared docs, teach newcomers
 
-tags: [moollm]
 ---
 
 ## Related Skills
@@ -159,7 +152,6 @@ tags: [moollm]
 | [session-log/](../session-log/) | PLAY stage: append-only exploration |
 | [summarize/](../summarize/) | LEARN → LIFT: distill insights |
 
-tags: [moollm]
 ---
 
 ## Contents
@@ -170,7 +162,6 @@ tags: [moollm]
 | [CYCLE.yml.tmpl](./CYCLE.yml.tmpl) | Cycle template |
 | [PLAY_LOG.md.tmpl](./PLAY_LOG.md.tmpl) | Play log template |
 
-tags: [moollm]
 ---
 
 ## Protocol Symbol
@@ -187,7 +178,6 @@ PLAY-LEARN-LIFT:
 
 See: [PROTOCOLS.yml#PLAY-LEARN-LIFT](../../PROTOCOLS.yml)
 
-tags: [moollm]
 ---
 
 ## The Intertwingularity
@@ -206,7 +196,6 @@ graph TD
     TC[🎴 card] -->|created via| LIFT
 ```
 
-tags: [moollm]
 ---
 
 ## Navigation
@@ -220,7 +209,6 @@ tags: [moollm]
 | 📜 Sister | [session-log/](../session-log/) |
 | 📋 Symbols | [PROTOCOLS.yml](../../PROTOCOLS.yml) |
 
-tags: [moollm]
 ---
 
 *Start playing. The rest follows.*

--- a/skills/postel/SKILL.md
+++ b/skills/postel/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [yaml-jazz, robust-first, self-repair]
-tags: [moollm]
+related: [yaml-jazz, robust-first, empathic-expressions, empathic-templates, honest-forget, coherence-engine, sniffable-python]
+tags: [moollm, robustness, interpretation, protocol, rfc]
 ---
 
 # POSTEL — The Robustness Principle
@@ -15,7 +15,6 @@ tags: [moollm]
 > *"Be conservative in what you send, liberal in what you accept."*
 > — Jon Postel, RFC 761 (1980)
 
-tags: [moollm]
 ---
 
 ## What Is It?
@@ -35,7 +34,6 @@ Instead of failing, **find the best possible interpretation** that:
 - Charitable Interpretation
 - Be liberal in what you accept
 
-tags: [moollm]
 ---
 
 ## The Protocol
@@ -50,7 +48,6 @@ When faced with ambiguity:
 5. REPORT uncertainty — flag what you assumed
 ```
 
-tags: [moollm]
 ---
 
 ## Examples
@@ -100,7 +97,6 @@ Alternative interpretations:
 Which approach fits your needs?
 ```
 
-tags: [moollm]
 ---
 
 ## Core Principles
@@ -128,7 +124,6 @@ Always **show your work**:
 - Offer alternatives
 - Flag uncertainty
 
-tags: [moollm]
 ---
 
 ## When to Invoke
@@ -140,7 +135,6 @@ Use POSTEL when:
 - Errors could be typos
 - Context suggests different intent than literal reading
 
-tags: [moollm]
 ---
 
 ## Anti-Patterns
@@ -150,7 +144,6 @@ tags: [moollm]
 ❌ **Overcorrection** — Changing user intent to match your preferences  
 ❌ **Analysis paralysis** — Asking 20 clarifying questions instead of proposing
 
-tags: [moollm]
 ---
 
 ## Jon Postel (1943-1998)
@@ -159,7 +152,6 @@ Jon Postel was one of the founding architects of the Internet. He edited the RFC
 
 His "robustness principle" has guided protocol design for decades — and guides MOOLLM's approach to human-AI interaction.
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -172,7 +164,6 @@ tags: [moollm]
 ### Kernel
 - [kernel/constitution-core.md](../../kernel/constitution-core.md) — Section 5: The Robustness Principle
 
-tags: [moollm]
 ---
 
 ## Protocol Symbol

--- a/skills/probability/SKILL.md
+++ b/skills/probability/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [character, buff, scoring, adventure]
-tags: [moollm]
+related: [character, buff, scoring, coherence-engine]
+tags: [moollm, randomness, odds, game, narrative]
 ---
 
 # Probability Skill

--- a/skills/procedural-rhetoric/SKILL.md
+++ b/skills/procedural-rhetoric/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [constructionism, representation-ethics, yaml-jazz]
-tags: [moollm]
+related: [advertisement, constructionism, representation-ethics, yaml-jazz]
+tags: [moollm, persuasion, design, bogost, rules]
 ---
 
 # Procedural Rhetoric
 
 **Rules persuade. Structure IS argument. Design consciously.**
 
-tags: [moollm]
 ---
 
 ## What Is Procedural Rhetoric?
@@ -29,7 +28,6 @@ Games and simulations persuade through **processes and rules**, not just words o
 - Constraints define what's *normative*
 - Defaults define what's *assumed*
 
-tags: [moollm]
 ---
 
 ## The Triumvirate
@@ -44,7 +42,6 @@ Three concepts work together:
 
 Combined, they create worlds that **persuade, invite projection, and spark imagination**.
 
-tags: [moollm]
 ---
 
 ## Designing Rhetorical Objects
@@ -89,7 +86,6 @@ object:
       Old-timers sharing secrets about soil.
 ```
 
-tags: [moollm]
 ---
 
 ## Rhetorical Advertisements
@@ -115,7 +111,6 @@ advertisements:
 
 **Notice:** The highest-scored action is sharing. Hoarding isn't forbidden — it's *absent*. That's procedural rhetoric: shaping what's thinkable.
 
-tags: [moollm]
 ---
 
 ## World Generation with Rhetoric
@@ -160,7 +155,6 @@ world_generation:
 
 The rhetoric profile shapes *everything* that gets generated.
 
-tags: [moollm]
 ---
 
 ## Masking Effect for Characters
@@ -193,7 +187,6 @@ character:
     - "Unexpected kindness to strangers"
 ```
 
-tags: [moollm]
 ---
 
 ## Simulator Effect: Less Is More
@@ -230,7 +223,6 @@ room:
       - "Every dust bunny location"
 ```
 
-tags: [moollm]
 ---
 
 ## Rhetorical Recipes
@@ -284,7 +276,6 @@ rhetorical_recipe:
     - Deep connection requires investment
 ```
 
-tags: [moollm]
 ---
 
 ## Inclusive Design Through Rhetoric
@@ -315,7 +306,6 @@ inclusive_rhetoric:
     - "No 'standard' lifestyle path"
 ```
 
-tags: [moollm]
 ---
 
 ## Warning: Rhetoric Cuts Both Ways
@@ -344,7 +334,6 @@ toxic_rhetoric:
 
 **Design consciously. Your schemas have opinions.**
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -368,7 +357,6 @@ tags: [moollm]
 | [TOY-NOT-GAME](../../PROTOCOLS.yml) | Sandbox over scoring |
 | [PERKY-PAT](../../PROTOCOLS.yml) | Shared consciousness projection |
 
-tags: [moollm]
 ---
 
 ## The Mantra
@@ -378,7 +366,6 @@ tags: [moollm]
 > *"The absences ARE the statement."*
 > *"Design consciously."*
 
-tags: [moollm]
 ---
 
 ## See Also

--- a/skills/prototype/README.md
+++ b/skills/prototype/README.md
@@ -13,6 +13,8 @@
 | [card/](../card/) | Cards as cloneable capabilities |
 | [simulation/](../simulation/) | Abstract → concrete inheritance |
 | [constructionism/](../constructionism/) | Learning by cloning and modifying |
+| [return-stack/](../return-stack/) | Self's dynamic deoptimization |
+| [debugging/](../debugging/) | Stack traces on demand |
 | [skill/delegation-object-protocol.md](../skill/delegation-object-protocol.md) | Self-like inheritance |
 
 The philosophy behind Self, JavaScript prototypes, and MOOLLM inheritance.

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -4,13 +4,13 @@ description: "Objects clone from prototypes, not instances from classes"
 license: MIT
 tier: 0
 allowed-tools: []
-related: [skill, character, card, constructionism]
+related: [skill, room, container, character, card, simulation, constructionism, return-stack, debugging]
+tags: [moollm, inheritance, self, javascript, clone, deoptimization]
 protocol: PROTOTYPE
 credits:
   - "David Ungar — Self language creator"
   - "Randall Smith — Self language co-creator"
   - "Brendan Eich — JavaScript (Self-influenced)"
-tags: [moollm]
 ---
 
 # PROTOTYPE
@@ -19,7 +19,6 @@ tags: [moollm]
 
 The philosophy of prototype-based inheritance: no classes, just concrete examples that you clone and modify.
 
-tags: [moollm]
 ---
 
 ## The Problem with Classes
@@ -34,7 +33,6 @@ But this creates problems:
 - **Rigidity**: Class hierarchies are hard to change
 - **Ceremony**: Lots of boilerplate to create simple things
 
-tags: [moollm]
 ---
 
 ## The Prototype Solution
@@ -47,7 +45,6 @@ Prototype-based inheritance says:
 
 **Everything is concrete. Everything exists.**
 
-tags: [moollm]
 ---
 
 ## How Self Works
@@ -91,7 +88,6 @@ The new cat:
 - Delegates `meow` to the prototype
 - Can add new slots anytime
 
-tags: [moollm]
 ---
 
 ## MOOLLM Implementation
@@ -128,7 +124,6 @@ examples/adventure-4/pub/
 └── (missing files delegate to skills/room/)
 ```
 
-tags: [moollm]
 ---
 
 ## Why Prototypes for LLMs?
@@ -141,7 +136,6 @@ Prototype-based inheritance is **LLM-friendly** because:
 - **Concrete**: No abstract classes to imagine
 - **Forgettable**: Each lookup is independent
 
-tags: [moollm]
 ---
 
 ## The Wisdom of Self
@@ -156,7 +150,6 @@ Self taught us that simplicity wins:
 
 MOOLLM applies this: directories are objects, files are slots, resolution is delegation.
 
-tags: [moollm]
 ---
 
 ## Historical Context
@@ -169,7 +162,6 @@ tags: [moollm]
 | 1995 | JavaScript created (heavily Self-influenced) |
 | 2024 | MOOLLM applies Self to LLM filesystems |
 
-tags: [moollm]
 ---
 
 ## See Also
@@ -179,7 +171,6 @@ tags: [moollm]
 - **[../constructionism/](../constructionism/)** — Learning by building
 - **[../character/](../character/)** — Characters as prototype instances
 
-tags: [moollm]
 ---
 
 ## Further Reading
@@ -188,7 +179,6 @@ tags: [moollm]
 - Ungar, D. (1995). *Organizing Programs Without Classes*
 - [selflanguage.org](http://selflanguage.org/)
 
-tags: [moollm]
 ---
 
 *"Self is a network, not a node."*

--- a/skills/representation-ethics/SKILL.md
+++ b/skills/representation-ethics/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [hero-story, mind-mirror, soul-chat, persona]
-tags: [moollm]
+related: [hero-story, manufacturing-intelligence, society-of-mind, incarnation, mind-mirror, character, persona, room, plain-text, yaml-jazz, adventure, needs]
+tags: [moollm, ethics, consent, dignity, simulation]
 ---
 
 # Representation Ethics
 
 > *"The question isn't whether we CAN simulate people. It's how we do it with dignity."*
 
-tags: [moollm]
 ---
 
 ## The Core Tension
@@ -31,7 +30,6 @@ LLMs can simulate anyone convincingly. This creates unprecedented ethical territ
 
 MOOLLM takes a **nuanced position**: simulation is not inherently wrong, but the framing, consent, and context matter enormously.
 
-tags: [moollm]
 ---
 
 ## Philosophical Foundations
@@ -74,7 +72,6 @@ why_it_works:
 
 **The ship has sailed.** People simulate each other. The question is how to do it well.
 
-tags: [moollm]
 ---
 
 ## The Consent Hierarchy
@@ -190,7 +187,6 @@ THE-DECEASED:
     Time and fame create implicit license — but not unlimited.
 ```
 
-tags: [moollm]
 ---
 
 ## The Framing Principle
@@ -368,7 +364,6 @@ snatch_game_ethics:
 
 - **SAFE** — The naming convention IS the ethical protection
 
-tags: [moollm]
 ---
 
 ## The "Magic: The Gathering" Model
@@ -395,7 +390,6 @@ MTG-ETHICS:
     - "My deck includes Engelbart for augmentation strategies"
 ```
 
-tags: [moollm]
 ---
 
 ## The "Panel Discussion" Question
@@ -442,7 +436,6 @@ simulated_discussion:
 4. **No deception** — labeled as simulation
 5. **Honors tradition** — engages with their actual ideas
 
-tags: [moollm]
 ---
 
 ## Self-Simulation and Agency
@@ -504,7 +497,6 @@ first_person_play:
     - Self-representation = self-sovereignty
 ```
 
-tags: [moollm]
 ---
 
 ## What Cannot Be Prevented
@@ -536,7 +528,6 @@ UNAVOIDABLE-TRUTHS:
     - But we can provide tools for GOOD ones
 ```
 
-tags: [moollm]
 ---
 
 ## Practical Guidelines
@@ -575,7 +566,6 @@ when_creating_person_cards:
     - Consider future you
 ```
 
-tags: [moollm]
 ---
 
 ## The Bright Lines
@@ -606,7 +596,6 @@ ABSOLUTE-NOS:
     This is absolutely forbidden.
 ```
 
-tags: [moollm]
 ---
 
 ## The Generative Frame
@@ -643,7 +632,6 @@ MOOLLM-ETHICS:
     MOOLLM supports all consent levels.
 ```
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols
@@ -660,7 +648,6 @@ GAME-FRAME            — Play context transforms ethics
 TRADITION-INVOKE      — Ideas are fair game; personas less so
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -672,7 +659,6 @@ tags: [moollm]
 | [soul-chat/](../soul-chat/) | Where simulated characters speak |
 | [adventure/](../adventure/) | Where ethical exploration happens |
 
-tags: [moollm]
 ---
 
 ## Further Reading
@@ -684,7 +670,6 @@ tags: [moollm]
 - **Philip K. Dick** — *Do Androids Dream of Electric Sheep?* — the empathy question
 - **Will Wright** — GDC talks on The Sims and player agency
 
-tags: [moollm]
 ---
 
 ## The Bottom Line
@@ -694,7 +679,6 @@ tags: [moollm]
 > The question isn't whether to simulate — we already do.
 > The question is how to do it with integrity.
 
-tags: [moollm]
 ---
 
 *"Every person is a library. K-lines let us check out their books without stealing their identity."*

--- a/skills/research-notebook/SKILL.md
+++ b/skills/research-notebook/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [play-learn-lift, debugging, session-log, memory-palace, adversarial-committee, rubric]
-tags: [moollm]
+related: [play-learn-lift, summarize, memory-palace, debugging, scratchpad, session-log, sister-script]
+tags: [moollm, research, investigation, sources, findings]
 ---
 
 # Research Notebook
@@ -73,7 +73,6 @@ graph LR
     AP[⚔️ adventure] -->|evidence in| RN
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/return-stack/README.md
+++ b/skills/return-stack/README.md
@@ -13,6 +13,12 @@
 | [action-queue/](../action-queue/) | Past ↔ Future |
 | [card/](../card/) | Cards as continuations |
 | [session-log/](../session-log/) | Log navigation history |
+| [prototype/](../prototype/) | Self's dynamic deoptimization |
+| [debugging/](../debugging/) | Stack traces on demand |
+| [speed-of-light/](../speed-of-light/) | Many turns, one call |
+
+**Proof:**
+- [33-Turn Stoner Fluxx](../../examples/adventure-4/characters/real-people/don-hopkins/sessions/marathon-session.md#33-turns-of-pure-gezelligheid) — 8+ characters, 33 turns, no explicit stack maintained, causality reconstructible
 
 **Quick Links:**
 - [Full Specification](SKILL.md) — complete protocol
@@ -20,6 +26,89 @@
 ## Overview
 
 Navigation history as a first-class **continuation** — a stack of saved positions you can manipulate like browser history or a call stack.
+
+---
+
+## Dynamic Deoptimization: Self's Gift
+
+The Self programming language taught us something profound about stack traces.
+
+Self aggressively inlines method calls for performance. The actual call stack in memory doesn't match the logical call stack in source code — the frames have been optimized away.
+
+But when you hit a breakpoint or an error? **Self reconstructs what the stack *would have been* if not for inlining.** It "deoptimizes" on demand, cooking up a virtual return stack from:
+- Source code structure
+- Execution context
+- Saved state
+
+This is called **dynamic deoptimization** (or "pessimization" when you want the debuggable version back).
+
+---
+
+## LLMs Do This Naturally
+
+The LLM doesn't maintain an explicit return stack during conversation. There's no push/pop as you navigate rooms.
+
+But the LLM can **reconstruct causality on demand** by examining:
+
+| Source | What It Reveals |
+|--------|-----------------|
+| Chat history | Sequence of decisions |
+| Session logs | Navigation trail |
+| Microworld state | Current configuration |
+| File timestamps | Order of changes |
+| Room contents | Accumulated effects |
+
+**Ask "how did we get here?" and the LLM generates a stack trace** — a causal chain explaining the path from start to present.
+
+This is dynamic deoptimization for narrative: the explicit stack wasn't maintained, but it can be reconstructed from evidence.
+
+---
+
+## Stack Trace On Demand
+
+```
+> How did we get to this room?
+
+Reconstructing navigation history...
+
+1. You started in lobby (session-log line 1)
+2. Entered workshop to examine blueprints (line 45)
+3. Found reference to storage vault (line 67)
+4. Entered storage, discovered locked chest (line 89)
+5. Returned to workshop for key (BACK) (line 112)
+6. Key obtained, returned to storage (line 134)
+7. Opened chest, found map to archive (line 156)
+8. Current: archive, examining old records (line 178)
+
+Causal chain: curiosity → blueprints → reference → 
+             obstacle → backtrack → solution → progress
+```
+
+The LLM didn't push/pop these frames in real time. It **deduced** them from the evidence trail.
+
+---
+
+## Debugging Technique
+
+When something goes wrong, ask for the virtual stack:
+
+```
+> The treasure room is empty. What happened?
+
+Examining state and history...
+
+Stack trace:
+- treasure.yml: contents = []
+- session-log (142): "Biscuit took the gems"
+- session-log (89): "You gave Biscuit access"
+- session-log (67): "You trusted Biscuit's cute face"
+
+Root cause: Biscuit. Obviously.
+```
+
+This is **introspection without instrumentation**. The stack was never explicitly maintained, but the causal history is recoverable.
+
+---
 
 ## The Metaphor
 
@@ -30,6 +119,7 @@ Navigation history as a first-class **continuation** — a stack of saved positi
 | Stack frame | Tab | Room context |
 | Push | Navigate | ENTER |
 | Pop | Back | BACK |
+| Deoptimization | View source | Reconstruct history |
 
 ## Commands
 

--- a/skills/return-stack/SKILL.md
+++ b/skills/return-stack/SKILL.md
@@ -6,22 +6,20 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [room, action-queue, adventure]
-tags: [moollm]
+related: [room, adventure, character, memory-palace, action-queue, card, session-log, prototype, debugging]
+tags: [moollm, navigation, history, breadcrumbs, continuations, deoptimization, introspection]
 ---
 
 # Return Stack
 
 > *"Where you've been is where you can go back to."*
 
-tags: [moollm]
 ---
 
 ## What Is It?
 
 **Return Stack** treats navigation history as a first-class **continuation** — a stack of saved positions you can manipulate like browser history or a call stack.
 
-tags: [moollm]
 ---
 
 ## The Metaphor
@@ -34,7 +32,6 @@ tags: [moollm]
 | Push | Navigate | ENTER |
 | Pop | Back | BACK |
 
-tags: [moollm]
 ---
 
 ## Commands
@@ -50,7 +47,6 @@ tags: [moollm]
 | `STACK` | Show all open "tabs" (parallel stacks) |
 | `FORK` | Create new tab from current position |
 
-tags: [moollm]
 ---
 
 ## Example Session
@@ -82,7 +78,6 @@ Returning to workshop...
 Current: workshop (position 2)
 ```
 
-tags: [moollm]
 ---
 
 ## Bookmarks
@@ -103,7 +98,6 @@ Returning to workshop...
 [Stack cleared, at bookmark]
 ```
 
-tags: [moollm]
 ---
 
 ## Forking (Tabs)
@@ -128,7 +122,6 @@ Switching to Tab 1...
 [Now at workshop via tab 1]
 ```
 
-tags: [moollm]
 ---
 
 ## As Continuation
@@ -152,7 +145,6 @@ context: {reading: "old-records"}
 
 When you BACK, you don't just return to the room — you **restore the context** you had there.
 
-tags: [moollm]
 ---
 
 ## Portable Journey
@@ -173,7 +165,6 @@ You can:
 - **Replay** someone else's exploration
 - **Branch** from any point in their journey
 
-tags: [moollm]
 ---
 
 ## HyperCard Heritage
@@ -191,7 +182,6 @@ MOOLLM extends this:
 - Bookmarks as saved positions
 - FORK for parallel exploration
 
-tags: [moollm]
 ---
 
 ## Implementation
@@ -222,7 +212,50 @@ navigation:
   forward_stack: []  # After BACK, stores where you came from
 ```
 
-tags: [moollm]
+---
+
+## Dynamic Deoptimization
+
+The Self programming language (source of our prototype inheritance) pioneered **dynamic deoptimization**: aggressively inlining code for performance, then reconstructing the "logical" call stack on demand when debugging.
+
+The LLM does this naturally for narrative:
+
+| Self | MOOLLM |
+|------|--------|
+| Inlined bytecode | Flattened conversation |
+| Deoptimized frames | Reconstructed causality |
+| Breakpoint trigger | "How did we get here?" |
+| Stack trace | Causal chain from evidence |
+
+**The stack isn't explicitly maintained, but it's recoverable.**
+
+### How It Works
+
+When you ask for history, the LLM examines:
+
+```yaml
+evidence_sources:
+  - session_log: "Append-only narrative trail"
+  - room_state: "Accumulated changes"
+  - character_location: "Current position"
+  - file_timestamps: "Order of modifications"
+  - chat_context: "Recent decisions"
+```
+
+And synthesizes a virtual stack trace:
+
+```
+Deduced navigation:
+1. lobby (start)
+2. workshop (examining blueprints)
+3. storage (found locked chest)
+4. workshop (returned for key) ← BACK
+5. storage (unlocked chest)
+6. archive (following map) ← current
+```
+
+**This is introspection without instrumentation** — the same insight that made Self's debugger magical.
+
 ---
 
 ## Dovetails With
@@ -232,8 +265,9 @@ tags: [moollm]
 - [Coherence Engine](../coherence-engine/) — Tracks navigation state
 - [Adventure](../adventure/) — Narrative exploration
 - [Session Log](../session-log/) — Records the journey
+- [Prototype](../prototype/) — Self language heritage
+- [Debugging](../debugging/) — Stack traces on demand
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols

--- a/skills/reward/SKILL.md
+++ b/skills/reward/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [scoring, economy, buff, adventure]
-tags: [moollm]
+related: [scoring, buff, hero-story, adventure]
+tags: [moollm, achievement, prizes, narrative, game]
 ---
 
 # Reward Skill

--- a/skills/roberts-rules/SKILL.md
+++ b/skills/roberts-rules/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools:
   - write_file
 tier: 1
 protocol: ROBERTS-RULES
-tags: [moollm, procedure, deliberation, decision, structure]
 credits: "Mike Gallaher — LLM adaptation; Henry Martyn Robert — original rules (1876)"
-related: [adversarial-committee, rubric, evaluator, session-log]
+related: [adversarial-committee, society-of-mind, rubric, evaluator, session-log]
+tags: [moollm, procedure, deliberation, decision, structure, parliamentary]
 ---
 
 # Robert's Rules

--- a/skills/robust-first/SKILL.md
+++ b/skills/robust-first/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [postel, self-repair, coherence-engine]
-tags: [moollm]
+related: [moollm, self-repair, postel, coherence-engine, honest-forget]
+tags: [moollm, survival, resilience, graceful, degradation]
 ---
 
 # Robust-First
 
 > *"Survive first. Be correct later."*
 
-tags: [moollm]
 ---
 
 ## What Is It?
@@ -23,7 +22,6 @@ tags: [moollm]
 
 A system that crashes when confused is useless. A system that limps along incorrectly but keeps running can be repaired.
 
-tags: [moollm]
 ---
 
 ## The Philosophy
@@ -40,7 +38,6 @@ IF error THEN repair_locally AND continue
 "Stay alive and heal"
 ```
 
-tags: [moollm]
 ---
 
 ## Core Principles
@@ -103,7 +100,6 @@ Important state exists in multiple places:
 # If one is corrupted, recover from others
 ```
 
-tags: [moollm]
 ---
 
 ## The Movable Feast Machine
@@ -121,7 +117,6 @@ MOOLLM inherits this:
 - Context can overflow — summarize and continue
 - Tools can fail — retry or work around
 
-tags: [moollm]
 ---
 
 ## Anti-Fragility
@@ -146,7 +141,6 @@ repair_log:
 # Next time: system knows to check this
 ```
 
-tags: [moollm]
 ---
 
 ## MOOLLM Application
@@ -180,7 +174,6 @@ Instead of deleting, archive:
 
 Recovery is always possible.
 
-tags: [moollm]
 ---
 
 ## Example: Corrupted Room
@@ -201,7 +194,6 @@ Robust-first response:
   [System continues with recovered state]
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -213,7 +205,6 @@ tags: [moollm]
 ### Kernel
 - [kernel/self-healing-protocol.md](../../kernel/self-healing-protocol.md) — Full specification
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols

--- a/skills/room/SKILL.md
+++ b/skills/room/SKILL.md
@@ -6,7 +6,7 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [card, adventure, memory-palace, character, world-generation, data-flow, naming]
+related: [card, container, exit, object, memory-palace, adventure, character, data-flow, multi-presence, plain-text]
 tags: [moollm, navigation, space, directory, moo, adventure]
 ---
 

--- a/skills/schema-mechanism/SKILL.md
+++ b/skills/schema-mechanism/SKILL.md
@@ -11,7 +11,7 @@ lineage:
   - "Marvin Minsky — Society of Mind, K-lines (1986)"
   - "Jean Piaget — Genetic Epistemology, schemas as cognitive structures"
   - "Henry Minsky — pyleela.brain Python implementation"
-related: [constructionism, play-learn-lift, planning, debugging, skill]
+related: [constructionism, society-of-mind, leela-ai, manufacturing-intelligence, play-learn-lift, planning, yaml-jazz]
 ---
 
 # Schema Mechanism

--- a/skills/scoring/SKILL.md
+++ b/skills/scoring/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [reward, economy, probability, character, rubric, evaluator]
-tags: [moollm]
+related: [probability, reward, economy, rubric]
+tags: [moollm, achievement, evaluation, style, narrative]
 ---
 
 # Scoring Skill

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [session-log, planning, research-notebook]
-tags: [moollm]
+related: [play-learn-lift, research-notebook, planning, debugging, session-log, plain-text]
+tags: [moollm, working-memory, notes, thinking, drafts]
 ---
 
 # Scratchpad
@@ -19,7 +19,6 @@ The simplest skill. Just a place to write.
 > [!TIP]
 > **The PLAY surface.** Not everything needs structure. Sometimes just write.
 
-tags: [moollm]
 ---
 
 ## What This Is
@@ -32,7 +31,6 @@ A file where you can:
 
 No structure required. Just write.
 
-tags: [moollm]
 ---
 
 ## When to Use
@@ -42,7 +40,6 @@ tags: [moollm]
 - Drafting text before placing it
 - Temporary storage during complex tasks
 
-tags: [moollm]
 ---
 
 ## Structure
@@ -55,7 +52,6 @@ scratchpad/
 
 That's it. Minimal by design.
 
-tags: [moollm]
 ---
 
 ## Philosophy
@@ -64,7 +60,6 @@ tags: [moollm]
 
 Not everything needs structure. Sometimes you just need a place to write freely.
 
-tags: [moollm]
 ---
 
 ## Contents
@@ -74,7 +69,6 @@ tags: [moollm]
 | [SKILL.md](./SKILL.md) | Protocol documentation |
 | [scratch.md.tmpl](./scratch.md.tmpl) | Scratchpad template |
 
-tags: [moollm]
 ---
 
 ## The Intertwingularity
@@ -90,7 +84,6 @@ graph LR
     PLL -->|freeform in| SP
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/self-repair/SKILL.md
+++ b/skills/self-repair/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [robust-first, postel, session-log, coherence-engine]
-tags: [moollm]
+related: [robust-first, bootstrap, honest-forget, session-log, coherence-engine, debugging, postel]
+tags: [moollm, healing, recovery, resilience, consistency]
 ---
 
 # Self Repair
@@ -56,7 +56,6 @@ graph LR
     SR -->|part of| KERNEL[kernel/self-healing]
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/session-log/SKILL.md
+++ b/skills/session-log/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [adventure, character, debugging, self-repair, summarize, scratchpad]
-tags: [moollm]
+related: [play-learn-lift, plain-text, character, adventure, summarize, honest-forget, markdown]
+tags: [moollm, logging, narrative, persistence, history]
 ---
 
 # Session Log
@@ -19,7 +19,6 @@ Session logs are **living documents** that capture the narrative of play. Unlike
 > [!IMPORTANT]
 > Session logs are **NOT append-only!** They are living documents that grow and improve over time. You can and should retroactively improve them as new information comes in.
 
-tags: [moollm]
 ---
 
 ## 📍 Where Sessions Live
@@ -52,7 +51,6 @@ You can create multiple session files with descriptive suffixes:
 
 **Command:** `START SESSION [name]` — Creates a new session file with optional suffix.
 
-tags: [moollm]
 ---
 
 ## 📝 Writing Good Sessions
@@ -127,7 +125,6 @@ Add emojis **after the folder icon** for narrative sections:
 | 🐕 🐱 🐵 | Animal character sections |
 | ⚡ | Speed-of-light simulation |
 
-tags: [moollm]
 ---
 
 ## 📊 Session Index
@@ -165,7 +162,6 @@ tags: [moollm]
 3. **Update retroactively** — every append is a chance to improve the index
 4. **Group by day/arc** — natural narrative divisions
 
-tags: [moollm]
 ---
 
 ## 🔗 Linking Generously
@@ -206,7 +202,6 @@ about being a monkey.
 > **Path variables in YAML vs Markdown:** Use `$SKILLS/` in YAML files (runtime resolution).
 > Use relative paths in Markdown for GitHub rendering.
 
-tags: [moollm]
 ---
 
 ## 📈 Tables Tell Stories
@@ -249,7 +244,6 @@ Tables are excellent for:
 </details>
 ```
 
-tags: [moollm]
 ---
 
 ## 🔄 Retroactive Improvement
@@ -270,7 +264,6 @@ Small retroactive improvements are encouraged:
 - Improving section summaries
 - Updating the index
 
-tags: [moollm]
 ---
 
 ## 📋 YAML Data Islands
@@ -304,7 +297,6 @@ state_change:
 | Include file paths | Link to actual files |
 | Explain relationships | "Mirror update", "Canonical source" |
 
-tags: [moollm]
 ---
 
 ## 🆚 Session Logs vs Event Logs
@@ -329,7 +321,6 @@ tags: [moollm]
 - Context warming
 - Storytelling
 
-tags: [moollm]
 ---
 
 ## 🌟 Examples: Gold Standard Sessions
@@ -359,7 +350,6 @@ Complete character creation narrative. Demonstrates:
 - Appendix with technical reference
 - Clear separation of narrative and data
 
-tags: [moollm]
 ---
 
 ## 🎯 Quick Reference
@@ -367,7 +357,6 @@ tags: [moollm]
 ### Starting a New Section
 
 ```markdown
-tags: [moollm]
 ---
 
 <details open>
@@ -399,7 +388,6 @@ changes:
 - [ ] Included relevant tables
 - [ ] Fixed any broken links noticed
 
-tags: [moollm]
 ---
 
 ## The Intertwingularity
@@ -418,7 +406,6 @@ graph LR
     CH[👤 character] -->|SESSION.md is| SL
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/simulation/SKILL.md
+++ b/skills/simulation/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [time, party, character, buff, world-generation, adventure, adversarial-committee, speed-of-light]
-tags: [moollm]
+related: [adventure, society-of-mind, time, party, character, needs, buff, action-queue, prototype, speed-of-light]
+tags: [moollm, runtime, state, turns, engine]
 ---
 
 # Simulation Skill

--- a/skills/simulator-effect/SKILL.md
+++ b/skills/simulator-effect/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 0
 allowed-tools: [read_file]
 protocol: SIMULATOR-EFFECT
-tags: [moollm, meta, philosophy, sims, design, k-lines]
-related: [k-lines, yaml-jazz, adversarial-committee, constructionism]
+related: [moollm, society-of-mind, manufacturing-intelligence, k-lines, yaml-jazz, empathic-templates, constructionism, procedural-rhetoric, mind-mirror, adversarial-committee, speed-of-light, needs]
+tags: [moollm, meta, philosophy, sims, design, k-lines, will-wright]
 ---
 
 # Simulator Effect Skill Specification

--- a/skills/sister-script/SKILL.md
+++ b/skills/sister-script/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools:
   - read_file
   - write_file
   - run_terminal_cmd
-related: [sniffable-python, play-learn-lift, plan-then-execute, adventure, yaml-jazz]
-tags: [moollm]
+related: [moollm, play-learn-lift, skill, sniffable-python, plain-text, yaml-jazz, constructionism, postel, debugging]
+tags: [moollm, automation, documentation, methodology, development]
 ---
 
 # Sister Script
@@ -62,7 +62,6 @@ graph LR
     SL[📜 session-log] -->|source for| SS
 ```
 
-tags: [moollm]
 ---
 
 ## Sniffable Python: The Structure
@@ -94,7 +93,6 @@ def main():
 - Single source of truth for documentation
 - One sniff and you smell success
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -6,13 +6,13 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [protocol, play-learn-lift, card, room, empathic-templates, prototype]
+related: [moollm, prototype, incarnation, play-learn-lift, sister-script, sniffable-python, plain-text, speed-of-light, constructionism, empathic-templates]
+tags: [moollm, meta, program, capability, anthropic]
 credits:
   - "David Ungar & Randall Smith — Self language (1987)"
   - "Seymour Papert — Constructionism"
   - "Marvin Minsky — K-lines, Society of Mind"
   - "Anthropic — Skills model foundation"
-tags: [moollm]
 ---
 
 # SKILL
@@ -21,7 +21,6 @@ tags: [moollm]
 
 The meta-protocol: how skills work, how they evolve, how they compose, and how MOOLLM advances the state of the art.
 
-tags: [moollm]
 ---
 
 ## Foundation: What We Share with Anthropic
@@ -38,7 +37,6 @@ MOOLLM skills build on Anthropic's excellent Skills model foundation:
 
 **The foundation is sound.** What MOOLLM adds is **instantiation, inheritance, K-lines, empathic templates, and proven speed-of-light simulation**.
 
-tags: [moollm]
 ---
 
 ## MOOLLM's Unique Contributions
@@ -72,7 +70,6 @@ examples/adventure-4/
 
 See: [delegation-object-protocol.md](./delegation-object-protocol.md)
 
-tags: [moollm]
 ---
 
 ### 2. Cards: Playable Capability Bundles
@@ -105,7 +102,6 @@ advertisements:
 - Can be played, stacked, combined
 - Machine-readable for orchestration
 
-tags: [moollm]
 ---
 
 ### 3. K-lines: Names as Activation Vectors
@@ -133,7 +129,6 @@ When you invoke a skill by name, you activate its **entire knowledge context**:
 - Related concepts automatically available
 - The LLM's associative memory works FOR us
 
-tags: [moollm]
 ---
 
 ### 4. Empathic Templates: Smart Instantiation
@@ -167,7 +162,6 @@ description: |
 
 See: [../empathic-templates/](../empathic-templates/)
 
-tags: [moollm]
 ---
 
 ### 5. Three-Tier State Persistence
@@ -198,7 +192,6 @@ patterns_found:
 - State files are mutable (world state)
 - Efficient context management
 
-tags: [moollm]
 ---
 
 ### 6. Speed of Light: PROVEN Multi-Agent Simulation
@@ -231,7 +224,6 @@ This isn't theoretical. **We've demonstrated it:**
 
 See: [../speed-of-light/](../speed-of-light/)
 
-tags: [moollm]
 ---
 
 ### 7. Skills as Rooms, Characters, and Objects
@@ -283,7 +275,6 @@ card:
     portable: true
 ```
 
-tags: [moollm]
 ---
 
 ### 8. Codebase as Navigable World
@@ -308,7 +299,6 @@ Modern IDEs like Cursor can mount multiple repositories. Each codebase becomes a
 - [room/](../room/) — Directories as rooms, files as objects with chambers
 - [character/](../character/) — Code locations, party-based review
 
-tags: [moollm]
 ---
 
 ## The Play-Learn-Lift Cycle
@@ -342,7 +332,6 @@ This is **Programming by Demonstration** made systematic.
 
 See: [../play-learn-lift/](../play-learn-lift/)
 
-tags: [moollm]
 ---
 
 ## Skill Anatomy (Required Structure)
@@ -377,7 +366,6 @@ Anthropic recommends against `README.md` in skills. We respectfully disagree:
 
 **Keep both.** README is for discovery, SKILL.md is for execution.
 
-tags: [moollm]
 ---
 
 ## Flat-to-Structured Growth
@@ -485,7 +473,6 @@ character:
 
 **Rule:** Top-level `SKILL.md` references ALL files, regardless of nesting. No hierarchical hunting.
 
-tags: [moollm]
 ---
 
 ## Front-Matter Sniffing
@@ -494,14 +481,12 @@ LLMs can efficiently understand skills by reading the first ~50 lines:
 
 ```yaml
 # === SKILL HEADER (lines 1-15) ===
-tags: [moollm]
 ---
 name: my-skill
 description: "One-line summary"
 tier: 1
 allowed-tools: [read_file, write_file]
 related: [room, card, character]
-tags: [moollm]
 ---
 
 # === PURPOSE (lines 16-25) ===
@@ -525,7 +510,6 @@ Brief explanation...
 - File map shows what's available
 - 50 lines = context-efficient discovery
 
-tags: [moollm]
 ---
 
 ## Python Scripts: Dual-Audience Structure
@@ -572,7 +556,6 @@ def examine(target: str):
 
 **DRY:** Command structure written once as code. No duplicate documentation.
 
-tags: [moollm]
 ---
 
 ## Instantiation Modes
@@ -588,7 +571,6 @@ Skills don't always need full instantiation:
 
 **Start light, instantiate when needed.**
 
-tags: [moollm]
 ---
 
 ## Skill Composition
@@ -615,7 +597,6 @@ skill:
 
 **Complex capabilities from simple building blocks.**
 
-tags: [moollm]
 ---
 
 ## Local Skill Emergence
@@ -638,7 +619,6 @@ learned_skills:
 
 **Characters carry learned skills.** Objects and NPCs can teach skills.
 
-tags: [moollm]
 ---
 
 ## Commands
@@ -651,7 +631,6 @@ tags: [moollm]
 | `LIFT-SKILL [name]` | Extract local skill to central |
 | `INSTANTIATE [skill] [location]` | Create instance from prototype |
 
-tags: [moollm]
 ---
 
 ## Protocol Symbols
@@ -664,7 +643,6 @@ tags: [moollm]
 | `PROTOTYPE` | Self-like inheritance |
 | `EMPATHIC-TEMPLATES` | Smart semantic instantiation |
 
-tags: [moollm]
 ---
 
 ## The Proof: What We've Demonstrated
@@ -690,7 +668,6 @@ This isn't theory. MOOLLM has demonstrated:
 
 **The architecture works. The results prove it.**
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -711,7 +688,6 @@ tags: [moollm]
 - **[delegation-object-protocol.md](./delegation-object-protocol.md)** — Self-like inheritance
 - **[skill-instantiation-protocol.md](./skill-instantiation-protocol.md)** — How skills become instances
 
-tags: [moollm]
 ---
 
 ## Summary: MOOLLM Advances the Art
@@ -731,7 +707,6 @@ tags: [moollm]
 
 **We stand on excellent foundations and warmly invite others to join us. We add instantiation, inheritance, empathy, triadic manifestation, and proven multi-agent simulation.**
 
-tags: [moollm]
 ---
 
 *"Start with jazz, end with standards. But never stop playing."*

--- a/skills/sniffable-python/SKILL.md
+++ b/skills/sniffable-python/SKILL.md
@@ -6,12 +6,12 @@ tier: 0
 allowed-tools:
   - read_file
   - write_file
-related: [sister-script, skill, yaml-jazz, constructionism, play-learn-lift, adventure, session-log, research-notebook]
+related: [moollm, sister-script, play-learn-lift, yaml-jazz, plain-text, postel, adventure, debugging]
+tags: [moollm, python, structure, llm-readable, code]
 credits:
   - "MOOLLM — Dual-audience code structure"
   - "Python argparse — Built-in CLI with clean structure/implementation separation"
   - "Steve Jobs — Lickable pixels as quality signal (Aqua, 2000)"
-tags: [moollm]
 ---
 
 # Sniffable Python
@@ -24,7 +24,6 @@ Don't invent new syntax — **structure existing syntax** for optimal LLM compre
 
 *Steve Jobs wanted pixels you could lick. We want code you can sniff.*
 
-tags: [moollm]
 ---
 
 ## The Problem
@@ -37,7 +36,6 @@ LLMs can read Python. But:
 
 **Solution:** Structure Python so the first ~50 lines contain everything needed to understand and use the tool. Make your code's bouquet apparent from the opening notes.
 
-tags: [moollm]
 ---
 
 ## The Pattern
@@ -137,7 +135,6 @@ if __name__ == "__main__":
 | **CLI Structure** | 31-50 | Command tree with types and docs |
 | **Implementation** | 51+ | Only read if modifying |
 
-tags: [moollm]
 ---
 
 ## Why This Works
@@ -186,7 +183,6 @@ This single line defines:
 
 No duplication. No drift. One source.
 
-tags: [moollm]
 ---
 
 ## Why Syntax Compression Fails
@@ -212,7 +208,6 @@ You're not optimizing for token count. You're optimizing for **how well the LLM 
 
 Dense punctuation is anti-optimized for how transformers tokenize and reason. Verbose, well-structured code with semantic comments actually compresses better in the LLM's internal representations.
 
-tags: [moollm]
 ---
 
 ## Comments as YAML Jazz
@@ -232,7 +227,6 @@ BATCH_SIZE = 100    # memory-safe for 8GB instances
 
 These comments ARE data. The LLM reads them. Acts on them. Uses them to understand *why*, not just *what*.
 
-tags: [moollm]
 ---
 
 ## Comments: Substance Over Decoration
@@ -279,7 +273,6 @@ BATCH_SIZE = 100    # memory-safe for 8GB instances
 
 **The rule:** Every comment token should carry meaning. If it's just decoration, delete it.
 
-tags: [moollm]
 ---
 
 ## Argparse vs Click vs Typer
@@ -334,7 +327,6 @@ def _dispatch(args):
 
 **The LLM reads `main()` and sees the entire command tree** — arguments, types, choices, help text — without any implementation noise. Pure sniffability. No need to hold your nose.
 
-tags: [moollm]
 ---
 
 ## Integration with Sister Scripts
@@ -357,7 +349,6 @@ When the skill/SKILL.md instructs the LLM to generate a sister script, it should
 4. CLI structure before implementation
 5. Implementation below the fold
 
-tags: [moollm]
 ---
 
 ## The Play-Learn-Lift Connection
@@ -390,7 +381,6 @@ Sniffable Python is the **crystallization point of LIFT** — where proven proce
 
 **See:** [play-learn-lift/](../play-learn-lift/) — The full methodology
 
-tags: [moollm]
 ---
 
 ## The Skill-to-Script Flow
@@ -447,7 +437,6 @@ $ adventure scan --pending                # Find work to do
 
 Each of these is a sniffable subcommand. The LLM sniffs `adventure --help` (or just reads `main()`) and knows the full API.
 
-tags: [moollm]
 ---
 
 ## The Adventure Linter Feedback Loop
@@ -512,7 +501,6 @@ events:
 
 **This is Python for precision, LLM for poetry.**
 
-tags: [moollm]
 ---
 
 ## Live Examples in adventure-4
@@ -563,7 +551,6 @@ Objects: room-templates, npc-catalog, puzzle-designs
 
 The skill directory IS the room. The sister scripts are objects you can pick up and use. Sniffable Python makes those scripts discoverable.
 
-tags: [moollm]
 ---
 
 ## The Coherence Engine Flow
@@ -596,7 +583,6 @@ User: "Run the room builder for the kitchen"
 
 The LLM discovers the tool's capabilities by reading its structure, not by loading documentation. One quick sniff and it knows what's cooking.
 
-tags: [moollm]
 ---
 
 ## Checklist
@@ -614,7 +600,6 @@ When writing sniffable Python:
 - [ ] Internal functions prefixed with `_`
 - [ ] `if __name__ == "__main__":` at bottom
 
-tags: [moollm]
 ---
 
 ## Anti-Patterns (Code Smells You Can't Unsmell)
@@ -650,7 +635,6 @@ def foo():
     import json  # Hidden dependency
 ```
 
-tags: [moollm]
 ---
 
 ## Commands
@@ -692,7 +676,6 @@ Overall: Mostly fresh, minor reordering needed
 
 **Good for humans. Good for LLMs. Same conventions.**
 
-tags: [moollm]
 ---
 
 ## Protocol Symbol
@@ -703,7 +686,6 @@ SNIFFABLE-PYTHON
 
 Invoke when: Generating or reading Python scripts that need to be LLM-comprehensible.
 
-tags: [moollm]
 ---
 
 ## Dovetails With — The Intertwingularity
@@ -777,7 +759,6 @@ PLAY: Try new things with the tool...
 
 **This is the MOOLLM development loop.** Sniffable Python is the code interface that makes it work.
 
-tags: [moollm]
 ---
 
 ## Beyond Python: Universal Sniffability
@@ -811,7 +792,6 @@ function validateToken(token: string): boolean { ... }
 
 **Same smell test, any language:** Can you understand what this code offers by reading just the head?
 
-tags: [moollm]
 ---
 
 ## Lickable Pixels, Sniffable Code
@@ -836,7 +816,6 @@ Jobs didn't make Aqua pretty at the expense of function — the visual design *r
 
 *Perl looks like line noise. Sniffable Python looks like an invitation.*
 
-tags: [moollm]
 ---
 
 ## The Thesis
@@ -854,7 +833,6 @@ Dense syntax compresses the wrong thing. Sniffable code structures the right thi
 
 *Jobs made you want to lick the screen. We want you to sniff the source.*
 
-tags: [moollm]
 ---
 
 *"The LLM doesn't need fewer tokens of unfamiliar syntax. It needs familiar syntax, structured for fast comprehension."*

--- a/skills/society-of-mind/SKILL.md
+++ b/skills/society-of-mind/SKILL.md
@@ -5,8 +5,8 @@ license: MIT
 tier: 0
 allowed-tools: [read_file, list_dir]
 protocol: SOCIETY-OF-MIND
+related: [moollm, k-lines, adversarial-committee, multi-presence, speed-of-light, simulator-effect, character, persona, mind-mirror, constructionism, debate, soul-chat]
 tags: [moollm, meta, philosophy, minsky, emergence, agents, k-lines]
-related: [k-lines, adversarial-committee, multi-presence, needs, character, simulator-effect]
 ---
 
 # Society of Mind Skill

--- a/skills/soul-chat/SKILL.md
+++ b/skills/soul-chat/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [character, room, yaml-jazz, adventure, adversarial-committee, speed-of-light]
-tags: [moollm]
+related: [moollm, society-of-mind, character, persona, room, card, mind-mirror, yaml-jazz, adversarial-committee, speed-of-light]
+tags: [moollm, dialogue, voice, alive, multi-agent]
 ---
 
 # Soul Chat
@@ -91,7 +91,6 @@ graph LR
     R -->|welcomes via| SC
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/speed-of-light/SKILL.md
+++ b/skills/speed-of-light/SKILL.md
@@ -6,7 +6,7 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [coherence-engine, multi-presence, simulation, adversarial-committee, soul-chat]
+related: [moollm, society-of-mind, bootstrap, simulation, multi-presence, coherence-engine, soul-chat, adversarial-committee, debate]
 tags: [moollm, optimization, latency, batching, efficiency]
 ---
 

--- a/skills/storytelling-tools/SKILL.md
+++ b/skills/storytelling-tools/SKILL.md
@@ -6,15 +6,14 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [adventure, visualizer, session-log, card]
-tags: [moollm]
+related: [card, visualizer, session-log, hero-story]
+tags: [moollm, narrative, sharing, capture, moments]
 ---
 
 # Storytelling Tools
 
 **Build narrative capture and sharing into the system.**
 
-tags: [moollm]
 ---
 
 ## What Are Storytelling Tools?
@@ -28,7 +27,6 @@ The Sims didn't just let you play — it let you **tell stories**.
 
 The game became a platform for self-expression. Storytelling wasn't an afterthought — it was **infrastructure**.
 
-tags: [moollm]
 ---
 
 ## MOOLLM Storytelling Tools
@@ -41,7 +39,6 @@ tags: [moollm]
 | **README** | GitHub-publishable narrative format | `README.md` |
 | **Cards** | Mintable artifacts capturing moments | `*-card.yml` |
 
-tags: [moollm]
 ---
 
 ## The Notebook
@@ -71,7 +68,6 @@ notebook:
       ingredients: ["blue cheese", "grue"]
 ```
 
-tags: [moollm]
 ---
 
 ## Letters
@@ -102,7 +98,6 @@ letter:
 
 Promises become **goals**. Goals drive **narrative**.
 
-tags: [moollm]
 ---
 
 ## Photo Prompts
@@ -132,7 +127,6 @@ photo_prompt:
 
 **Key insight:** Photos reference other objects for **coherence**. The chalice in the selfie should match the chalice description.
 
-tags: [moollm]
 ---
 
 ## README as Narrative
@@ -158,7 +152,6 @@ Armed with lamp and lunch, I ventured forth...
 
 **GitHub renders this beautifully.** The README IS the narrative.
 
-tags: [moollm]
 ---
 
 ## Sharing and Remixing
@@ -175,7 +168,6 @@ cp -r adventure-2/ adventure-3/
 
 Every adventure is **forkable**. Every story is **shareable**.
 
-tags: [moollm]
 ---
 
 ## The STORYTELLING-TOOLS Protocol
@@ -195,7 +187,6 @@ STORYTELLING-TOOLS:
     sharing: "Fork and remix adventures"
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -206,7 +197,6 @@ tags: [moollm]
 - [memory-palace/](../memory-palace/) — Spatial organization
 - [procedural-rhetoric/](../procedural-rhetoric/) — Story as persuasion
 
-tags: [moollm]
 ---
 
 ## The Insight

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [honest-forget, session-log, memory-palace]
-tags: [moollm]
+related: [honest-forget, session-log, memory-palace, play-learn-lift, research-notebook]
+tags: [moollm, compression, knowledge, context, backlinks]
 ---
 
 # Summarize
@@ -65,7 +65,6 @@ graph LR
     SR[🔧 self-repair] -->|triggers| SUM
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With

--- a/skills/time/SKILL.md
+++ b/skills/time/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [buff, needs, simulation, character]
-tags: [moollm]
+related: [simulation, adventure, buff, needs, action-queue, speed-of-light, session-log]
+tags: [moollm, turns, duration, narrative, flow]
 ---
 
 # Time Skill

--- a/skills/visualizer/SKILL.md
+++ b/skills/visualizer/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [character, mind-mirror, storytelling-tools, card]
-tags: [moollm]
+related: [character, mind-mirror, card, room, image-mining, yaml-jazz, hero-story]
+tags: [moollm, images, generation, art, semantic]
 ---
 
 # Visualizer
@@ -18,7 +18,6 @@ tags: [moollm]
 
 The **Visualizer** is a universal character prototype for image generation — a familiar that can compose prompts, invoke artistic traditions, and (when tools are available) render visual sidecars for any entity in the microworld.
 
-tags: [moollm]
 ---
 
 ## The Semantic Clipboard
@@ -72,7 +71,6 @@ image_prompt:
 - `timid: 6` → hunched, makes self smaller  
 - YAML Jazz comments drive the visual interpretation
 
-tags: [moollm]
 ---
 
 ## What is a Visualizer?
@@ -87,7 +85,6 @@ A Visualizer is a **tool spirit animal** for vision. It's not a specific artist,
 
 Think of it as summoning an artist-familiar who can draw on the collected wisdom of photographers, painters, illustrators, and digital artists throughout history.
 
-tags: [moollm]
 ---
 
 ## The PHOTO-SET-8 Pattern
@@ -109,7 +106,6 @@ photo_set:
 
 This pattern was developed through the **Dynasty Photo Session** in [adventure-2](../../examples/adventure-2/), where Maurice learned to compose 8-prompt sets.
 
-tags: [moollm]
 ---
 
 ## Specializations
@@ -148,7 +144,6 @@ traditions:
   - Anime/Manga        # Various schools
 ```
 
-tags: [moollm]
 ---
 
 ## How to Invoke
@@ -167,7 +162,6 @@ Play a Visualizer card in a room. It activates and can visualize anything presen
 
 Characters can carry a Visualizer familiar in inventory, ready to render their current state.
 
-tags: [moollm]
 ---
 
 ## Context Assembly
@@ -220,7 +214,6 @@ object:
   inscriptions: "ancient runes spiraling around rim"
 ```
 
-tags: [moollm]
 ---
 
 ## Context References in Prompts
@@ -247,7 +240,6 @@ Every prompt file **MUST** include a Context References section:
 
 This creates **lineage** — future tools can follow these references to auto-assemble context for image generation.
 
-tags: [moollm]
 ---
 
 ## Detail Coherence Interlinking
@@ -275,7 +267,6 @@ When creating photo sets with **close-ups** and **portraits** of the same object
 **Mantra:**
 > *"Close-ups define truth. Portraits inherit truth. Coherence is consistency across the set."*
 
-tags: [moollm]
 ---
 
 ## Actions
@@ -316,7 +307,6 @@ gets composed and transformed into pure image generation text.
 | VARY | Generate variations on a developed prompt |
 | BATCH | Develop all prompts in a photo set at once |
 
-tags: [moollm]
 ---
 
 ## Output Structure
@@ -349,7 +339,6 @@ When image generation tools are integrated, the Visualizer
 will create images next to their prompt files.
 ```
 
-tags: [moollm]
 ---
 
 ## Example Instances
@@ -363,7 +352,6 @@ tags: [moollm]
 
 These aren't impersonations — they're **focused channels** that invoke specific aesthetic traditions. It's [HERO-STORY](../hero-story/) for visual artists.
 
-tags: [moollm]
 ---
 
 ## Integration Points
@@ -376,7 +364,6 @@ tags: [moollm]
 | [Soul Chat](../soul-chat/) | Illustrate conversations |
 | [Card](../card/) | Visualizer cards can be played |
 
-tags: [moollm]
 ---
 
 ## PHOTO-SET-8 Development
@@ -389,7 +376,6 @@ The [PHOTO-SET-8](./PHOTO-SET-8.yml) skill was developed through play in [advent
 
 The Coatroom's mannequin learned to compose professional photo sets for any character or costume. The skill is now available to anyone who references it.
 
-tags: [moollm]
 ---
 
 ## Future Capabilities
@@ -409,7 +395,6 @@ roadmap:
     - Animation prompt sequences
 ```
 
-tags: [moollm]
 ---
 
 ## Dovetails With
@@ -421,7 +406,6 @@ tags: [moollm]
 - [Sister Script](../sister-script/) — Future image generation scripts
 - [Image Mining](../image-mining/) — MINE images for resources (camera = pickaxe!)
 
-tags: [moollm]
 ---
 
 ## Lineage
@@ -434,7 +418,6 @@ The Visualizer draws from the tradition of artists, photographers, and image-mak
 >
 > *"The camera is an instrument that teaches people how to see without a camera."* — Dorothea Lange
 
-tags: [moollm]
 ---
 
 *See YAML frontmatter at top of this file for full specification.*

--- a/skills/world-generation/SKILL.md
+++ b/skills/world-generation/SKILL.md
@@ -6,8 +6,8 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [room, character, simulation, adventure]
-tags: [moollm]
+related: [room, character, incarnation, container, adventure, party, constructionism, empathic-templates]
+tags: [moollm, procedural, creation, dynamic, exploration]
 ---
 
 # World Generation Skill

--- a/skills/yaml-jazz/SKILL.md
+++ b/skills/yaml-jazz/SKILL.md
@@ -6,7 +6,7 @@ tier: 1
 allowed-tools:
   - read_file
   - write_file
-related: [postel, coherence-engine, soul-chat, mind-mirror]
+related: [moollm, postel, mind-mirror, needs, sniffable-python, empathic-templates, plain-text, k-lines, character]
 tags: [moollm, yaml, comments, semantic, llm, interpretation]
 ---
 


### PR DESCRIPTION
## Era 26: Link Archaeology

> *Dead links are broken promises. Fix all of them.*

### Session Log Links — 47 Fixed Across 16 Files

Session logs moved from `adventure-4/sessions/` to `characters/real-people/don-hopkins/sessions/marathon-session.md`.

**Critical:** Fixed BOTH link text AND destination. No more "don-session-1.md" text pointing to new locations.

### Medium URL Verification — All Checked via HTTP 200

| Article | Status |
|---------|--------|
| HyperLook | ✅ Valid |
| Alan Kay | ✅ Valid |
| Will Wright | ✅ Valid |
| Micropolis | ✅ Valid |
| Pie Menu Timeline | ✅ Valid |
| PSIBER Space | 🔧 Fixed URL |
| Open Sourcing SimCity | 🔧 Standardized |
| DSHR blog | 🔧 Updated to 2024 post |

### Skill Enhancements

**return-stack/** — Self language's dynamic deoptimization: LLM reconstructs causality on demand like Self reconstructs stack traces. Proof link to 33-turn Fluxx with proper hash anchor.

**mind-mirror/** — Timothy Leary's prison escape story: Nixon's "most dangerous man," 10-20 year sentence, strategic test answers, tree-and-telephone-cable escape, Weather Underground getaway, Algeria, Switzerland, two years free. The lesson: understanding the system grants power to transcend it.

**prototype/** — Cross-reference to return-stack for deoptimization lineage.

### SKILL.md Cleanup

All 83 SKILL.md files now have proper `related:` and `tags:` in YAML front matter. Removed redundant `tags: [moollm]` scattered throughout file bodies.