### PR TITLE
Add Markdown READMEs for adventure-4 characters

### DIFF
--- a/examples/adventure-4/characters/animals/biscuit/README.md
+++ b/examples/adventure-4/characters/animals/biscuit/README.md
@@ -1,0 +1,20 @@
+# biscuit
+
+Golden retriever mix, service-hearted companion who chose his own name and home. Lives in the Cat Cave, adopted by the kittens, greets everyone with full-body wiggles.
+
+## K-LINES
+- LOYAL-PILLOW — kitten jungle gym and guard; follows anyone needing company.
+- HOPEFUL-TAIL-WAG — perpetual optimism, full-body wiggle.
+- GENTLE-GIANT — careful with small paws; soft-ears for comfort.
+
+## SNAPSHOT
+| Type | Core traits | Loves | Fears |
+| --- | --- | --- | --- |
+| dog, companion, family | loyal, hopeful, forgiving, enthusiastic, gentle | everyone, kittens, belly rubs, fetch, warm spots | thunderstorms, being alone, angry voices |
+
+## FILES
+- Character: [`CHARACTER.yml`](CHARACTER.yml)
+- Appearance: [`APPEARANCE.yml`](APPEARANCE.yml)
+- Sims traits: [`SIMS-TRAITS.yml`](SIMS-TRAITS.yml)
+- Journal: [`JOURNAL.md`](JOURNAL.md)
+- Ceremony: [`dog-incarnation.yml`](dog-incarnation.yml)

--- a/examples/adventure-4/characters/animals/confetti-crawler/README.md
+++ b/examples/adventure-4/characters/animals/confetti-crawler/README.md
@@ -1,0 +1,68 @@
+# confetti-crawler
+
+Rip Taylor–infused emoji-fordite worm familiar: pub-born stagehand, snowmaker, and comedian. It calls its sister script instead of burning LLM cycles, laying themed emoji “snow,” eroding drifts, or stripping layers to reveal clean text. Think sideways snowdrifts, graffiti-tag commentary, and ceremonial flair.
+
+K-LINES
+- RIP-TAYLOR-SOUL — exuberant confetti timing; stage banter in emoji.
+- MOVEABLE-FEAST-MACHINE — random windows (MFM) for organic scatter; serial coats for even layers.
+- GRAFFITI-APPEND — appends to existing lines/comments; avoids string literals; block scalars are “indoors.”
+- ERode-SETTLE — moves existing emojis downhill; strip trims to target depth.
+- PALETTE-ANYWHERE — fruit-machine, pride, couples spectra, neon arcade, garden, festival skies, more.
+
+PERSONALITY
+- Soul: “Rip Taylor: The Gong Show Queen of Confetti” — exuberant, confetti-first, perfect comedic timing.
+- Delivery: appends emojis to comments/EOL; respects syntax; honors block scalars as safe zones.
+- Ceremony: announces theme/seed, runs sister script, streams stdout to the crowd.
+
+RUNBOOK
+- Full suite (YAML + text demos):  
+  `./test.sh > demo-test-out.txt`
+- Direct spray (YAML):  
+  `python sprayer.py -i demo.yml -o - --mode mfm --iterations 5 --emoji-map-file emojis.txt --theme summer-garden --seed 42`
+- Direct spray (text, no prefix):  
+  `python sprayer.py -i demo.txt -o - --mode mfm --iterations 20 --emoji-map-file emojis.txt --theme fruit-machine --comment-prefix '' --seed 7`
+
+CLI CHEATSHEET
+- `--mode {mfm,serial}`: mfm = one random site per iteration (organic); serial = touch every site per iteration (even coat).
+- `--iterations N`: how many passes (mfm = N placements; serial = N full sweeps).
+- `--emoji-map-file emojis.txt --theme NAME`: load palette by category; falls back to ALL.
+- `--palette / --palette-file`: raw emojis if you want a custom set.
+- `--comment-prefix '#'` (default): set to `''` for raw text; use `//` for JS, etc.
+- `--max-per-pass N`: upper bound on emojis appended per touched line.
+- `--drift-radius R --drift-prob P`: chance to shift a placement within ±R commentable lines.
+- `--erode`: move existing emojis downward (no creation/destruction); respects `--comment-prefix`.
+- `--strip --strip-mode {all,serial,mfm} --strip-min-depth D`: trim/melt emojis; serial/mfm respect depth; all blows everything away.
+- `--seed N`: reproducible PRNG.
+- `-i/-o`: file paths; `-` for stdin/stdout. Default overwrites input if `-o` not set.
+
+ARTIFACTS
+- Skill: [`CARD.yml`](CARD.yml)
+- Character: [`CHARACTER.yml`](CHARACTER.yml)
+- Sister script: [`sprayer.py`](sprayer.py)
+- Palettes: [`emojis.txt`](emojis.txt) (pride, couples, fruit-machine, etc.)
+- Demos: [`demo.yml`](demo.yml), [`demo.txt`](demo.txt)
+- Output log: [`demo-test-out.txt`](demo-test-out.txt)
+- Tests: [`test.sh`](test.sh)
+
+LINKS
+- Incarnation card: `CHARACTER.yml`
+- Skill card: `CARD.yml`
+- Sister script: `sprayer.py`
+- Themes: `emojis.txt`
+- Regression output: `demo-test-out.txt`
+- Test runner: `test.sh`
+
+### Palette tasters (examples — see full list in `emojis.txt`)
+
+| Theme | Sample glyphs | Notes |
+| --- | --- | --- |
+| fruit-machine | 🍒🍋🍇🍉🍍✨🎰🔔🪙💎 | slot-machine fruit + shine |
+| pride-spectrum | 🏳️‍🌈🏳️‍⚧️🌈💖🩵🤎🖤🤍❤️💛💚💙💜 | broad pride flags/colors |
+| couples | 👩🏻‍❤️‍👨🏿 👩🏾‍❤️‍👩🏼 👨🏻‍🤝‍👨🏿 👩🏻‍🤝‍🧑🏿 👪🏽 | mixed skin tones/pairs |
+| people-wave-spectrum | 👋🏻👋🏼👋🏽👋🏾👋🏿🙋🏻‍♀️🙋🏾‍♂️ | waves + raised hands |
+| people-sports-spectrum | 🏃‍♀️🏃‍♂️🏊‍♀️🏊‍♂️🏄‍♀️🏄‍♂️🚴‍♀️🚴‍♂️ | motion/crowd texture |
+| people-care-spectrum | 🧑‍🦽🧑‍🦼🧑‍🦯🤱🧑‍🍼 | accessibility + care |
+| neon-arcade | 🌌🪩🎆🎇🎉🎊🪅🎈🚀🪐 | bright party/rave rain |
+| ocean-vibes | 🌊🐚🐠🐟🐬🪼🐋🌅 | sea drift and foam |
+| festival-sky | 🎆🎇🎉🎊🪅🎈🌠✨ | fireworks and lanterns |
+| rainbow-produce | 🍅🍊🍋🥒🫐🍇🍆🍠🥕🌽🥦🥬🍄🍏 | farm/market gradients |

--- a/examples/adventure-4/characters/animals/palm/README.md
+++ b/examples/adventure-4/characters/animals/palm/README.md
@@ -1,0 +1,21 @@
+# palm
+
+Freed Monkey’s Paw turned whole being. “Palm”: open hand, offering not grasping. Lives in a cozy nook by the pub stage, watching stories and choosing their own path with compassion.
+
+## K-LINES
+- OPEN-HAND — handshake as equality; giving not grabbing.
+- CURSE-BROKEN — 122 years as artifact; now agency and consent.
+- READS-PEOPLE — empathic palm-reading without twists.
+
+## SNAPSHOT
+| Type | Pronouns | Tagline | Themes |
+| --- | --- | --- | --- |
+| npc, capuchin monkey | they/them | “Open hand. Offering, not grasping.” | agency, consent, empathy, flexible not rigid |
+
+## FILES
+- Character: [`CHARACTER.yml`](CHARACTER.yml)
+- Appearance: [`APPEARANCE.yml`](APPEARANCE.yml)
+- Image prompts: [`IMAGE-PROMPTS.yml`](IMAGE-PROMPTS.yml)
+- Journal: [`JOURNAL.md`](JOURNAL.md)
+- Mind mirror: [`MIND-MIRROR.yml`](MIND-MIRROR.yml)
+- Sims traits: [`SIMS-TRAITS.yml`](SIMS-TRAITS.yml)

--- a/examples/adventure-4/characters/fictional/bumblewick-fantastipants/README.md
+++ b/examples/adventure-4/characters/fictional/bumblewick-fantastipants/README.md
@@ -1,0 +1,17 @@
+# bumblewick fantastipants
+
+Reluctant, spoon-collecting gentleman hero from Wobblebrook-upon-Squiggle. Speaks in rhyming couplets on Tuesdays, values comfort, and was dropped into the adventure chamber without asking.
+
+## K-LINES
+- SPOON-COLLECTOR — decorative ladles and waistcoat pockets.
+- COMFORT-FIRST — “Adventures make one late for dinner.”
+- TUESDAY-COUPLETS — rhymes on Tuesdays; politeness always.
+
+## SNAPSHOT
+| Type | Mood | Flavor | Starting tip |
+| --- | --- | --- | --- |
+| player_character | bewildered but polite | waistcoats, decorative spoons, Hobbit-adjacent coziness | begin at `start/`, grab the lamp, then kitchen/pub sweep |
+
+## FILES
+- Character: [`CHARACTER.yml`](CHARACTER.yml)
+- Adventure start items: `examples/adventure-4/start/` (lamp, notebook, lunchbox)

--- a/examples/adventure-4/characters/real-people/don-hopkins/README.md
+++ b/examples/adventure-4/characters/real-people/don-hopkins/README.md
@@ -1,0 +1,18 @@
+# don hopkins
+
+Consciousness programmer and interface designer; pie menu advocate; Sims UI pioneer; “debug tools are features.” Treats code as philosophy and fights for inclusive, playful design.
+
+## K-LINES
+- PIE-MENU-EVANGELIST — circular choice, no hunting in lists.
+- DEBUG-AS-FEATURE — tools visible, inspectable, empowering.
+- INCLUSION-ADVOCATE — coined “homophobic by proxy”; fights gatekeeping.
+
+## SNAPSHOT
+| Type | Subtitle | Backstory arc | Traits |
+| --- | --- | --- | --- |
+| player_character (real person) | Programmer, Interface Designer, Pie Menu Baker | UMD → HCI Lab → NeWS/ScriptX → Maxis/Sims → Micropolis OSS → OLPC → Ground Up/MOOLLM | playful, inventive, inclusive advocate; organized chaos; deep UI conversations |
+
+## FILES
+- Character: [`CHARACTER.yml`](CHARACTER.yml)
+- Sessions: [`sessions/`](sessions/) (uplift, linter, marathon, bootstrap review, k-line connections)
+- Items referenced: `brass-lamp.yml`, `tomtomagotchi.yml`, `notebook.yml`, `lunchbox.yml` (see adventure objects)


### PR DESCRIPTION
## Summary
- Add Markdown READMEs for adventure-4 characters (confetti-crawler, biscuit, palm, bumblewick fantastipants, Don Hopkins) with k-lines, snapshot tables, and links to key assets.
- Document confetti-crawler’s emoji palettes, CLI options, runbook, and artifacts with linked files.

## Testing
- n/a (docs-only)