### PR TITLE
Don adventure 4 run 1

### DIFF
--- a/examples/adventure-4/street/README.md
+++ b/examples/adventure-4/street/README.md
@@ -134,7 +134,7 @@ The heart of town is where **Kay Lane** crosses **Lane Neverending**.
                  KAY LANE
                     │
                     │ N
-                    │ (toward Zork Row, Habitat Blvd)
+                    │ (toward Zork Row, Habitat Highway)
        ┌────────────┼────────────┐
   W ───┤    Lane Neverending     ├─── E
        │            │            │


### PR DESCRIPTION
## 🛤️ Street Grid README Polish

This PR cleans up the street grid documentation for consistency, completeness, and proper Mermaid rendering.

### Changes

**Mermaid Diagram Fix**
- Use `<br>` instead of `\n` for line breaks (proper Mermaid syntax)
- E-W streets now in vertical column (↓), N-S streets in horizontal row (→)
- Added all 10 E-W streets and all 7 N-S streets to the diagram

**Street Name Consistency**
- "Habitat Highway" everywhere (H-H alliteration)
- Fixed "MUD Row is south of Zork Row" (not "south of Adventure Avenue")
- All diagrams, tables, and references now use consistent naming

**Sound Test Completion**
- Added missing N-S streets: Turing Terrace (T-T), Licklider Lane (L-L)
- Now includes all 7 pioneer streets, alphabetized

**Glitch Lineage Update**
- Added Stewart Butterfield / Slack connection
- Game Neverending → Flickr, Glitch → Slack
- "(No Slack roads though — some things stay corporate.)"

### The Complete Grid

**N-S Streets (People):** Kay Lane, Engelbart Avenue, Minsky Way, Papert Path, Sutherland Street, Turing Terrace, Licklider Lane

**E-W Streets (Projects, north→south):**
1. Adventure Avenue (1976) — NORTHERN EDGE
2. Zork Row (1977-82)
3. MUD Row (1978)
4. Adams Avenue (1978)
5. Habitat Highway (1986)
6. Logo Lane (1987)
7. Sims Street (1989-2000)
8. Linden Lane (2003)
9. Glitch Way (2011-12)
10. Lane Neverending — SOUTHERN EDGE

---

*"Habitat Highway everywhere — H-H alliteration yeah baby"*