### PR TITLE
Fix Mermaid diagrams: replace \n with <br/> for line breaks

### DIFF
--- a/examples/adventure-4/street/lane-neverending/README.md
+++ b/examples/adventure-4/street/lane-neverending/README.md
@@ -15,7 +15,7 @@ flowchart TB
     subgraph NorthSide["NORTH SIDE OF STREET"]
         N_W3["     "]
         N_W2["     "]
-        N_W1["🏚️ ACME\n(closed)"]
+        N_W1["🏚️ ACME<br/>(closed)"]
         N_C["     "]
         N_E1["     "]
         N_E2["     "]
@@ -73,12 +73,12 @@ flowchart TB
     Start --> Walk["Walk east..."]
     Walk --> More["Keep walking..."]
     More --> Still["Still walking..."]
-    Still --> Back["You're back where\nyou started"]
+    Still --> Back["You're back where<br/>you started"]
     
     Back --> |"or"| West["Walk west..."]
     West --> MoreW["Keep walking..."]
     MoreW --> StillW["Still walking..."]
-    StillW --> BackW["You're back where\nyou started"]
+    StillW --> BackW["You're back where<br/>you started"]
 ```
 
 The street loops. East connects to west. West connects to east. You can walk forever and never leave. You can also walk forever and see everything.
@@ -116,16 +116,16 @@ Every segment of Lane Neverending shares common elements, implemented via the [F
 ```mermaid
 flowchart LR
     subgraph Prototypes["📋 Shared Prototypes"]
-        Lamp["🏮 Lamp Post\nMagical flame\nGrue-safe"]
-        Bench["🪑 Street Bench\nWrought iron\nComfortable"]
-        Cobbles["🟫 Cobblestones\nWell-worn\nHistoric"]
-        Gutter["💧 Gutter\nFunctional\nOccasional frog"]
+        Lamp["🏮 Lamp Post<br/>Magical flame<br/>Grue-safe"]
+        Bench["🪑 Street Bench<br/>Wrought iron<br/>Comfortable"]
+        Cobbles["🟫 Cobblestones<br/>Well-worn<br/>Historic"]
+        Gutter["💧 Gutter<br/>Functional<br/>Occasional frog"]
     end
     
     subgraph Instances["Each Street Gets"]
-        L1["Lamp Post\n(north side)"]
-        L2["Lamp Post\n(south side)"]
-        B1["Bench\n(unique carvings)"]
+        L1["Lamp Post<br/>(north side)"]
+        L2["Lamp Post<br/>(south side)"]
+        B1["Bench<br/>(unique carvings)"]
     end
     
     Prototypes --> |"flyweight"| Instances
@@ -148,9 +148,9 @@ flowchart LR
 flowchart TB
     Plaza["🌳 ORIGIN PLAZA"]
     
-    Plaza --> Tree["The Origin Tree\n(ancient, knowing)"]
-    Plaza --> Lamp["The Flickering Lamp\n(famous, mysterious)"]
-    Plaza --> Fountain["The Fountain\n(wishes optional)"]
+    Plaza --> Tree["The Origin Tree<br/>(ancient, knowing)"]
+    Plaza --> Lamp["The Flickering Lamp<br/>(famous, mysterious)"]
+    Plaza --> Fountain["The Fountain<br/>(wishes optional)"]
 ```
 
 The heart of Lane Neverending. The tree here is the source of cuttings throughout the neighborhood — including the one on [Leela's rooftop](leela-manufacturing/rooftop/).
@@ -183,8 +183,8 @@ The neighborhood pub sits just east of [Leela Manufacturing](leela-manufacturing
 
 ```mermaid
 flowchart LR
-    Leela["🏭 Leela\n5 Lane Neverending"]
-    Pub["🍺 The Pub\n(next door)"]
+    Leela["🏭 Leela<br/>5 Lane Neverending"]
+    Pub["🍺 The Pub<br/>(next door)"]
     
     Leela --> |"pneumatic tube"| Pub
     Leela --> |"walk"| Pub

--- a/examples/adventure-4/street/lane-neverending/center/README.md
+++ b/examples/adventure-4/street/lane-neverending/center/README.md
@@ -11,14 +11,14 @@
 ```mermaid
 flowchart TB
     subgraph Plaza["🌳 ORIGIN PLAZA"]
-        Tree["🌳 The Origin Tree\nAncient. Knowing."]
-        Lamp["🏮 The Famous Lamp\n(not the flickering one)"]
+        Tree["🌳 The Origin Tree<br/>Ancient. Knowing."]
+        Lamp["🏮 The Famous Lamp<br/>(not the flickering one)"]
         Bench["🪑 Thinking Benches"]
-        Fountain["⛲ The Fountain\nWishes optional"]
+        Fountain["⛲ The Fountain<br/>Wishes optional"]
     end
     
-    W1["← w1\nLeela & Pub"] --> Plaza
-    Plaza --> E1["e1 →\nGlitch Memorial"]
+    W1["← w1<br/>Leela & Pub"] --> Plaza
+    Plaza --> E1["e1 →<br/>Glitch Memorial"]
 ```
 
 ---
@@ -29,7 +29,7 @@ This is the original. All other "Origin Tree cuttings" throughout the neighborho
 
 ```mermaid
 flowchart TB
-    Origin["🌳 THE ORIGIN TREE\n(here, center)"]
+    Origin["🌳 THE ORIGIN TREE<br/>(here, center)"]
     
     Origin --> |"cutting"| Rooftop["Leela Rooftop"]
     Origin --> |"cutting"| Garden["Pub Garden"]

--- a/examples/adventure-4/street/lane-neverending/e1/README.md
+++ b/examples/adventure-4/street/lane-neverending/e1/README.md
@@ -10,13 +10,13 @@
 
 ```mermaid
 flowchart LR
-    Center["← center"] --> E1["E1\nYou Are Here"]
+    Center["← center"] --> E1["E1<br/>You Are Here"]
     E1 --> E2["e2 →"]
     
     subgraph Landmarks["This Block"]
-        Lamp["🏮 The Flickering Lamp\n(famous, mysterious)"]
-        Memorial["📸 Glitch Memorial\n(2011-2012)"]
-        Figure["💤 The Sleeping Figure\n(always here)"]
+        Lamp["🏮 The Flickering Lamp<br/>(famous, mysterious)"]
+        Memorial["📸 Glitch Memorial<br/>(2011-2012)"]
+        Figure["💤 The Sleeping Figure<br/>(always here)"]
     end
 ```
 
@@ -30,10 +30,10 @@ One lamp post on this street flickers. Just one. It has flickered for as long as
 flowchart TB
     Lamp["🏮 THE FLICKERING LAMP"]
     
-    Lamp --> Q1["Why does it flicker?\nUnknown."]
-    Lamp --> Q2["Has anyone fixed it?\nMany have tried."]
-    Lamp --> Q3["Is it trying to\ncommunicate?\nPossibly."]
-    Lamp --> Q4["Should we worry?\nProbably not.\n(Probably.)"]
+    Lamp --> Q1["Why does it flicker?<br/>Unknown."]
+    Lamp --> Q2["Has anyone fixed it?<br/>Many have tried."]
+    Lamp --> Q3["Is it trying to<br/>communicate?<br/>Possibly."]
+    Lamp --> Q4["Should we worry?<br/>Probably not.<br/>(Probably.)"]
 ```
 
 **Theories:**

--- a/examples/adventure-4/street/lane-neverending/e2/README.md
+++ b/examples/adventure-4/street/lane-neverending/e2/README.md
@@ -10,11 +10,11 @@
 
 ```mermaid
 flowchart TB
-    E1["← e1"] --> E2["E2\nMarket Square"]
+    E1["← e1"] --> E2["E2<br/>Market Square"]
     E2 --> E3["e3 →"]
     
     subgraph Square["THE SQUARE"]
-        Fountain["⛲ Fountain of\nInfinite Loops"]
+        Fountain["⛲ Fountain of<br/>Infinite Loops"]
         Shops["🏪 Storefronts"]
         Stage["🎭 Small stage"]
     end
@@ -27,7 +27,7 @@ flowchart TB
 ```mermaid
 flowchart LR
     Jug1["🏺 Jug A"] --> |"pours into"| Jug2["🏺 Jug B"]
-    Jug2 --> |"held by same figure\nwho holds"| Jug1
+    Jug2 --> |"held by same figure<br/>who holds"| Jug1
 ```
 
 A recursive monument to all programmers stuck in `while(true){}`.

--- a/examples/adventure-4/street/lane-neverending/e3/README.md
+++ b/examples/adventure-4/street/lane-neverending/e3/README.md
@@ -10,8 +10,8 @@
 
 ```mermaid
 flowchart LR
-    E2["← e2"] --> E3["E3\nYou Are Here"]
-    E3 --> |"THE LOOP!"| W3["w3 →\n(west side!)"]
+    E2["← e2"] --> E3["E3<br/>You Are Here"]
+    E3 --> |"THE LOOP!"| W3["w3 →<br/>(west side!)"]
     
     style E3 fill:#9b59b6,color:#fff
 ```
@@ -64,10 +64,10 @@ Why does Lane Neverending loop?
 flowchart TB
     Q["Why loop?"]
     
-    Q --> A1["So nobody is ever\n'at the end'"]
-    Q --> A2["So everywhere connects\nto everywhere"]
-    Q --> A3["Because real communities\ndon't have edges"]
-    Q --> A4["Because Game Neverending\nknew something we forgot"]
+    Q --> A1["So nobody is ever<br/>'at the end'"]
+    Q --> A2["So everywhere connects<br/>to everywhere"]
+    Q --> A3["Because real communities<br/>don't have edges"]
+    Q --> A4["Because Game Neverending<br/>knew something we forgot"]
 ```
 
 ---

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/README.md
@@ -15,33 +15,33 @@ The core of Leela Manufacturing is a sophisticated data pipeline that transforms
 ```mermaid
 flowchart TB
     subgraph ModelDev["🔬 Model Development (R&D Basement)"]
-        OD[("Object Model\nDevelopment")]
-        PD[("Pose Model\nDevelopment")]
+        OD[("Object Model<br/>Development")]
+        PD[("Pose Model<br/>Development")]
     end
 
     subgraph Training["🏋️ Training Pipeline"]
-        OT["Object Model\nTraining\n━━━━━━━━━━\n🎯 mAP: 0.947\n⚡ GPU×4"]
-        PT["Pose Model\nTraining\n━━━━━━━━━━\n🎯 PCK: 0.923\n⚡ GPU×4"]
+        OT["Object Model<br/>Training<br/>━━━━━━━━━━<br/>🎯 mAP: 0.947<br/>⚡ GPU×4"]
+        PT["Pose Model<br/>Training<br/>━━━━━━━━━━<br/>🎯 PCK: 0.923<br/>⚡ GPU×4"]
     end
 
     subgraph Deploy["🚀 Model Deployment"]
-        ODep["Object Detector\n━━━━━━━━━━━━\nyolo-leela-v2.3.7"]
-        PDep["Pose Estimator\n━━━━━━━━━━━━\npose-leela-v1.8.2"]
+        ODep["Object Detector<br/>━━━━━━━━━━━━<br/>yolo-leela-v2.3.7"]
+        PDep["Pose Estimator<br/>━━━━━━━━━━━━<br/>pose-leela-v1.8.2"]
     end
 
     OD --> OT --> ODep
     PD --> PT --> PDep
 
     subgraph Intake["📹 Video Intake"]
-        V[("VIDEO\nInput")]
+        V[("VIDEO<br/>Input")]
     end
 
     V --> |"Fork"| Objects
     V --> |"Fork"| Poses
 
     subgraph Processing["⚙️ Parallel Processing"]
-        Objects["🔵 OBJECTS\nBounding boxes\nClassifications\nConfidence scores"]
-        Poses["🟠 POSES\nJoint positions\nMovement vectors\nGesture signatures"]
+        Objects["🔵 OBJECTS<br/>Bounding boxes<br/>Classifications<br/>Confidence scores"]
+        Poses["🟠 POSES<br/>Joint positions<br/>Movement vectors<br/>Gesture signatures"]
     end
 
     ODep -.-> |"powers"| Objects
@@ -51,25 +51,25 @@ flowchart TB
     Poses --> |"merge"| Insights
 
     subgraph Understanding["💡 Understanding"]
-        Insights["🟡 INSIGHTS\n━━━━━━━━━━\nContext + Motion\n= Understanding"]
+        Insights["🟡 INSIGHTS<br/>━━━━━━━━━━<br/>Context + Motion<br/>= Understanding"]
     end
 
     Insights --> Actions
 
     subgraph ActionLayer["🐍 Python Actions"]
-        Actions["🟢 PYTHON ACTIONS\n━━━━━━━━━━━━━━━\nDefine high-level actions\nEmit to SQL tables\nTrigger alerts"]
+        Actions["🟢 PYTHON ACTIONS<br/>━━━━━━━━━━━━━━━<br/>Define high-level actions<br/>Emit to SQL tables<br/>Trigger alerts"]
     end
 
     Actions --> SQL
 
     subgraph Storage["💾 Storage"]
-        SQL[("🔘 SQL\nStructured\nIndexed\nQueryable")]
+        SQL[("🔘 SQL<br/>Structured<br/>Indexed<br/>Queryable")]
     end
 
     SQL --> PDA
 
     subgraph Assistant["🤖 Personal Data Assistant"]
-        PDA["💬 PDA\n━━━━━━━━━━━━━━━\nChat-driven interface\nGenerates queries\nAnalyzes results\nCreates visualizations"]
+        PDA["💬 PDA<br/>━━━━━━━━━━━━━━━<br/>Chat-driven interface<br/>Generates queries<br/>Analyzes results<br/>Creates visualizations"]
     end
 
     style V fill:#9b59b6,color:#fff
@@ -93,17 +93,17 @@ Two parallel pipelines develop and train the ML models that power perception:
 flowchart LR
     subgraph ObjectPipeline["Object Detection Track"]
         direction TB
-        OD1["📚 Research\nYOLO variants\nTransformers\nAttention mechanisms"]
-        OD2["🏋️ Training\nCOCO, ImageNet\nLeela-Custom-v3"]
-        OD3["🚀 Deploy\nyolo-leela-v2.3.7"]
+        OD1["📚 Research<br/>YOLO variants<br/>Transformers<br/>Attention mechanisms"]
+        OD2["🏋️ Training<br/>COCO, ImageNet<br/>Leela-Custom-v3"]
+        OD3["🚀 Deploy<br/>yolo-leela-v2.3.7"]
         OD1 --> OD2 --> OD3
     end
 
     subgraph PosePipeline["Pose Estimation Track"]
         direction TB
-        PD1["📚 Research\nKeypoint detectors\nTemporal models\nMotion predictors"]
-        PD2["🏋️ Training\nMPII, COCO-Pose\nLeela-Motion-v2"]
-        PD3["🚀 Deploy\npose-leela-v1.8.2"]
+        PD1["📚 Research<br/>Keypoint detectors<br/>Temporal models<br/>Motion predictors"]
+        PD2["🏋️ Training<br/>MPII, COCO-Pose<br/>Leela-Motion-v2"]
+        PD3["🚀 Deploy<br/>pose-leela-v1.8.2"]
         PD1 --> PD2 --> PD3
     end
 
@@ -118,14 +118,14 @@ Video enters and immediately forks to parallel processors:
 ```mermaid
 flowchart TB
     V["📹 VIDEO INPUT"]
-    V --> |"Frame by frame"| Fork{"Junction Alpha\n(Fork)"}
-    Fork --> |"Blue containers"| O["🔵 Object Detector\n━━━━━━━━━━━━━━\n• Bounding boxes\n• Classifications\n• Confidence: 97%\n\n'A cat. 97% sure.'"]
-    Fork --> |"Orange containers"| P["🟠 Pose Estimator\n━━━━━━━━━━━━━━\n• Joint positions\n• Movement vectors\n• Gestures\n\n'Waving. Definitely.'"]
+    V --> |"Frame by frame"| Fork{"Junction Alpha<br/>(Fork)"}
+    Fork --> |"Blue containers"| O["🔵 Object Detector<br/>━━━━━━━━━━━━━━<br/>• Bounding boxes<br/>• Classifications<br/>• Confidence: 97%<br/><br/>'A cat. 97% sure.'"]
+    Fork --> |"Orange containers"| P["🟠 Pose Estimator<br/>━━━━━━━━━━━━━━<br/>• Joint positions<br/>• Movement vectors<br/>• Gestures<br/><br/>'Waving. Definitely.'"]
     
-    O --> Merge{"Junction Beta\n(Merge)"}
+    O --> Merge{"Junction Beta<br/>(Merge)"}
     P --> Merge
     
-    Merge --> I["🟡 INSIGHTS\n━━━━━━━━━━━━━━\n'A cat (97%) is\nwaving (definitely).'"]
+    Merge --> I["🟡 INSIGHTS<br/>━━━━━━━━━━━━━━<br/>'A cat (97%) is<br/>waving (definitely).'"]
 
     style V fill:#9b59b6,color:#fff
     style O fill:#3498db,color:#fff
@@ -283,16 +283,16 @@ The Storage Complex contains prototypical containers for cloning:
 ```mermaid
 flowchart LR
     subgraph Storage["📦 STORAGE COMPLEX"]
-        A["Aisle A\n🪵 Wooden\nCrates, barrels\nchests, boxes"]
-        B["Aisle B\n🔩 Metal\nBins, drums\nlockers, safes"]
-        C["Aisle C\n👜 Soft\nSacks, bags\npouches, packs"]
-        D["Aisle D\n✨ Special\nParadox boxes\nQuantum containers"]
-        E["Aisle E\n🖼️ Display\nShelves, cases\nracks, mannequins"]
-        L["Aisle L\n🏭 Leela\nLogistics chests\n/dev/null box"]
+        A["Aisle A<br/>🪵 Wooden<br/>Crates, barrels<br/>chests, boxes"]
+        B["Aisle B<br/>🔩 Metal<br/>Bins, drums<br/>lockers, safes"]
+        C["Aisle C<br/>👜 Soft<br/>Sacks, bags<br/>pouches, packs"]
+        D["Aisle D<br/>✨ Special<br/>Paradox boxes<br/>Quantum containers"]
+        E["Aisle E<br/>🖼️ Display<br/>Shelves, cases<br/>racks, mannequins"]
+        L["Aisle L<br/>🏭 Leela<br/>Logistics chests<br/>/dev/null box"]
     end
     
-    Dolly["🏗️👑 Dolly\nLift Queen\nFork Queen"]
-    Clone["🔬 Cloning\nStation"]
+    Dolly["🏗️👑 Dolly<br/>Lift Queen<br/>Fork Queen"]
+    Clone["🔬 Cloning<br/>Station"]
     
     Dolly --> Storage
     Clone --> Storage

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/basement/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/basement/README.md
@@ -13,13 +13,13 @@ This is where Leela's future is invented.
 ```mermaid
 flowchart TB
     subgraph Basement["🔬 R&D LABORATORY"]
-        Z1["Zone 1\n✅ Controlled Experiments\n(relatively safe)"]
-        Z2["Zone 2\n🥽 Uncontrolled Experiments\n(wear goggles)"]
-        Z3["Zone 3\n📝 Theoretical Work\n(whiteboards only)"]
-        Z4["Zone 4\n🤪 Applied Madness\n(sign waiver first)"]
-        Z5["Zone 5\n📚 The Archive\n(historical knowledge)"]
-        Z6["Zone 6\n❄️ Cold Storage\n(temp-sensitive insights)"]
-        Z7["Zone 7\n⚠️ [SEALED]\n(we don't talk about Zone 7)"]
+        Z1["Zone 1<br/>✅ Controlled Experiments<br/>(relatively safe)"]
+        Z2["Zone 2<br/>🥽 Uncontrolled Experiments<br/>(wear goggles)"]
+        Z3["Zone 3<br/>📝 Theoretical Work<br/>(whiteboards only)"]
+        Z4["Zone 4<br/>🤪 Applied Madness<br/>(sign waiver first)"]
+        Z5["Zone 5<br/>📚 The Archive<br/>(historical knowledge)"]
+        Z6["Zone 6<br/>❄️ Cold Storage<br/>(temp-sensitive insights)"]
+        Z7["Zone 7<br/>⚠️ [SEALED]<br/>(we don't talk about Zone 7)"]
     end
     
     Z1 --> Z2 --> Z3 --> Z4
@@ -135,13 +135,13 @@ pie title Research Staff Composition
 
 ```mermaid
 flowchart TB
-    Shelf["🚫 THE FORBIDDEN SHELF\n━━━━━━━━━━━━━━━━━━\nExperiments TOO SUCCESSFUL"]
+    Shelf["🚫 THE FORBIDDEN SHELF<br/>━━━━━━━━━━━━━━━━━━<br/>Experiments TOO SUCCESSFUL"]
     
-    Shelf --> E7["Experiment 7\n'Perfect Answer'\nAnswers questions\nyou shouldn't ask"]
-    Shelf --> E12["Experiment 12\n'Infinite Insight'\nUnderstanding includes\nthings better left unknown"]
-    Shelf --> E23["Experiment 23\n'Completed Problem'\nSolved itself.\nKeeps solving OTHER problems."]
-    Shelf --> E31["Experiment 31\n'Wisdom Crystals'\n100% pure wisdom.\nMade everyone quit\nand become monks."]
-    Shelf --> E44["Experiment 44\n[REDACTED]"]
+    Shelf --> E7["Experiment 7<br/>'Perfect Answer'<br/>Answers questions<br/>you shouldn't ask"]
+    Shelf --> E12["Experiment 12<br/>'Infinite Insight'<br/>Understanding includes<br/>things better left unknown"]
+    Shelf --> E23["Experiment 23<br/>'Completed Problem'<br/>Solved itself.<br/>Keeps solving OTHER problems."]
+    Shelf --> E31["Experiment 31<br/>'Wisdom Crystals'<br/>100% pure wisdom.<br/>Made everyone quit<br/>and become monks."]
+    Shelf --> E44["Experiment 44<br/>[REDACTED]"]
 
     style Shelf fill:#e74c3c,color:#fff
 ```
@@ -154,7 +154,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    Door["⚠️ ZONE 7 DOOR\n━━━━━━━━━━━━━━\nPARADOX CONTAINMENT"]
+    Door["⚠️ ZONE 7 DOOR<br/>━━━━━━━━━━━━━━<br/>PARADOX CONTAINMENT"]
     
     Door --> |"sealed"| Inside["???"]
     
@@ -162,8 +162,8 @@ flowchart TB
         W1["Do not knock"]
         W2["Do not listen"]
         W3["Do not look too long"]
-        W4["If you hear your name,\nit's NOT calling you"]
-        W5["Personnel count is\nSUPPOSED to be uncertain"]
+        W4["If you hear your name,<br/>it's NOT calling you"]
+        W5["Personnel count is<br/>SUPPOSED to be uncertain"]
     end
     
     Door --> Warnings

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-1/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-1/README.md
@@ -13,32 +13,32 @@ Leela AI is a **Visual Intelligence Platform** — we transform video into under
 ```mermaid
 flowchart TB
     subgraph Cameras["📹 Leela's Seven Eyes"]
-        LOG1["LOG1\nLoading Docks"]
-        FAC1["FAC1\nFactory"]
-        INT1["INT1\nIntake"]
-        SHP1["SHP1\nShipping"]
-        LOB1["LOB1\nLobby"]
-        ROOF1["ROOF1\nRooftop"]
-        BASE1["BASE1\nBasement"]
+        LOG1["LOG1<br/>Loading Docks"]
+        FAC1["FAC1<br/>Factory"]
+        INT1["INT1<br/>Intake"]
+        SHP1["SHP1<br/>Shipping"]
+        LOB1["LOB1<br/>Lobby"]
+        ROOF1["ROOF1<br/>Rooftop"]
+        BASE1["BASE1<br/>Basement"]
     end
     
-    Cameras --> V["📹 VIDEO INTAKE\nLine V (Purple)"]
+    Cameras --> V["📹 VIDEO INTAKE<br/>Line V (Purple)"]
     
-    V --> Fork{"Junction Alpha\n(Fork)"}
+    V --> Fork{"Junction Alpha<br/>(Fork)"}
     
-    Fork --> O["🔵 OBJECT DETECTION\nLine O (Blue)"]
-    Fork --> P["🟠 POSE ESTIMATION\nLine P (Orange)"]
+    Fork --> O["🔵 OBJECT DETECTION<br/>Line O (Blue)"]
+    Fork --> P["🟠 POSE ESTIMATION<br/>Line P (Orange)"]
     
-    O --> Merge{"Junction Beta\n(Merge)"}
+    O --> Merge{"Junction Beta<br/>(Merge)"}
     P --> Merge
     
-    Merge --> I["🟡 INSIGHTS\nLine I (Gold)"]
+    Merge --> I["🟡 INSIGHTS<br/>Line I (Gold)"]
     
-    I --> A["🟢 PYTHON ACTIONS\nLine A (Green)"]
+    I --> A["🟢 PYTHON ACTIONS<br/>Line A (Green)"]
     
-    A --> SQL["💾 SQL STORAGE\nLine S (Silver)"]
+    A --> SQL["💾 SQL STORAGE<br/>Line S (Silver)"]
     
-    SQL --> PDA["💬 PDA\nPersonal Data Assistant"]
+    SQL --> PDA["💬 PDA<br/>Personal Data Assistant"]
 
     style V fill:#9b59b6,color:#fff
     style O fill:#3498db,color:#fff
@@ -61,17 +61,17 @@ Two parallel ML pipelines feed our processors:
 flowchart LR
     subgraph ObjectTrack["🔴 Object Detection Track"]
         direction TB
-        OD["Development\nYOLO, DETR, ViT"]
-        OT["Training\nCOCO, ImageNet"]
-        ODep["Deploy\nyolo-leela-v2.3.7"]
+        OD["Development<br/>YOLO, DETR, ViT"]
+        OT["Training<br/>COCO, ImageNet"]
+        ODep["Deploy<br/>yolo-leela-v2.3.7"]
         OD --> OT --> ODep
     end
     
     subgraph PoseTrack["🟠 Pose Estimation Track"]
         direction TB
-        PD["Development\nHRNet, ViTPose"]
-        PT["Training\nMPII, COCO-Pose"]
-        PDep["Deploy\npose-leela-v1.8.2"]
+        PD["Development<br/>HRNet, ViTPose"]
+        PT["Training<br/>MPII, COCO-Pose"]
+        PDep["Deploy<br/>pose-leela-v1.8.2"]
         PD --> PT --> PDep
     end
     
@@ -106,13 +106,13 @@ Workers in blue jumpsuits sort incoming containers:
 
 ```mermaid
 flowchart LR
-    Input["📦 Incoming\nContainers"] --> S1["Station 1\nClassification"]
-    S1 --> S2["Station 2\nPriority"]
-    S2 --> S3["Station 3\nRouting"]
+    Input["📦 Incoming<br/>Containers"] --> S1["Station 1<br/>Classification"]
+    S1 --> S2["Station 2<br/>Priority"]
+    S2 --> S3["Station 3<br/>Routing"]
     
     S3 --> LineO["→ Line O"]
     S3 --> LineP["→ Line P"]
-    S3 --> CWD["→ Confused\nWelcome Desk"]
+    S3 --> CWD["→ Confused<br/>Welcome Desk"]
     S3 --> Q["→ Quarantine"]
 
     style CWD fill:#f39c12,color:#fff

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-2/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-2/README.md
@@ -24,9 +24,9 @@ flowchart TB
     
     subgraph Furnace["🔥 THE INSIGHT FURNACE"]
         direction TB
-        Chamber["Combustion Chamber\n2000°K cognitive heat"]
-        Filter["Wisdom Filter\nRemoves assumptions"]
-        Crystal["Crystallization\nInsight formation"]
+        Chamber["Combustion Chamber<br/>2000°K cognitive heat"]
+        Filter["Wisdom Filter<br/>Removes assumptions"]
+        Crystal["Crystallization<br/>Insight formation"]
         Chamber --> Filter --> Crystal
     end
     
@@ -34,8 +34,8 @@ flowchart TB
     
     subgraph Outputs["⬆️ OUTPUTS"]
         Insights["✨ Refined Insights"]
-        BQ["Better Questions\n(recycled to Intake)"]
-        Wisdom["Pure Wisdom\n(rare, handle carefully)"]
+        BQ["Better Questions<br/>(recycled to Intake)"]
+        Wisdom["Pure Wisdom<br/>(rare, handle carefully)"]
     end
 
     style Furnace fill:#e74c3c,color:#fff
@@ -63,14 +63,14 @@ Eight glass-walled workspaces surround the Furnace, each tackling different prob
 ```mermaid
 flowchart TB
     subgraph Cells["PROCESSING CELLS"]
-        A["Cell A\n🏭 Manufacturing\nOptimization"]
-        B["Cell B\n🚛 Logistics\nPuzzles"]
-        C["Cell C\n⚙️ Process\nImprovement"]
-        D["Cell D\n📊 Data\nAnalysis"]
-        E["Cell E\n🤔 Meta-Problems\n(problems about problems)"]
-        F["Cell F\n⚡ Edge Cases"]
-        G["Cell G\n👁️ 'The Weird Ones'\n[CLASSIFIED]"]
-        H["Cell H\n🧹 Currently Empty\n(being decontaminated)"]
+        A["Cell A<br/>🏭 Manufacturing<br/>Optimization"]
+        B["Cell B<br/>🚛 Logistics<br/>Puzzles"]
+        C["Cell C<br/>⚙️ Process<br/>Improvement"]
+        D["Cell D<br/>📊 Data<br/>Analysis"]
+        E["Cell E<br/>🤔 Meta-Problems<br/>(problems about problems)"]
+        F["Cell F<br/>⚡ Edge Cases"]
+        G["Cell G<br/>👁️ 'The Weird Ones'<br/>[CLASSIFIED]"]
+        H["Cell H<br/>🧹 Currently Empty<br/>(being decontaminated)"]
     end
 
     style G fill:#9b59b6,color:#fff
@@ -122,18 +122,18 @@ This is where the Object Detection and Pose Estimation pipelines converge:
 ```mermaid
 flowchart LR
     subgraph From_Floor1["From Floor 1"]
-        Objects["🔵 Objects\n'A cat. 97% sure.'"]
-        Poses["🟠 Poses\n'Waving. Definitely.'"]
+        Objects["🔵 Objects<br/>'A cat. 97% sure.'"]
+        Poses["🟠 Poses<br/>'Waving. Definitely.'"]
     end
     
     Objects --> Merge{"Junction Beta"}
     Poses --> Merge
     
-    Merge --> Insight["🟡 Insight\n'A cat (97%) is\nwaving (definitely).'"]
+    Merge --> Insight["🟡 Insight<br/>'A cat (97%) is<br/>waving (definitely).'"]
     
     Insight --> Furnace["🔥 Insight Furnace"]
     
-    Furnace --> Understanding["✨ Understanding\n'The cat is greeting\nsomeone it recognizes.'"]
+    Furnace --> Understanding["✨ Understanding<br/>'The cat is greeting<br/>someone it recognizes.'"]
 
     style Objects fill:#3498db,color:#fff
     style Poses fill:#e67e22,color:#fff
@@ -150,7 +150,7 @@ flowchart LR
 flowchart TB
     FAC1["📹 FAC1"] --> |"watches"| Floor["Factory Floor"]
     Floor --> |"processes"| FAC1Feed["FAC1's feed"]
-    FAC1Feed --> |"becomes"| Insight["Insight about\nFAC1 watching"]
+    FAC1Feed --> |"becomes"| Insight["Insight about<br/>FAC1 watching"]
     Insight --> |"processed by"| Floor
 
     style FAC1 fill:#9b59b6,color:#fff

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-3/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/floor-3/README.md
@@ -14,19 +14,19 @@ flowchart LR
         Insights["✨ Refined Insights"]
     end
     
-    Insights --> Package["📦 Packaging\nStations"]
+    Insights --> Package["📦 Packaging<br/>Stations"]
     
-    Package --> Doc["📋 Documentation\nCenter"]
+    Package --> Doc["📋 Documentation<br/>Center"]
     
     Doc --> Dispatch["🚀 Dispatch"]
     
     subgraph Methods["Delivery Methods"]
-        Tube["🔵 Pneumatic Tube\n(local, fast)"]
-        Drone["🛸 Drone\n(medium range)"]
-        Truck["🚛 Truck\n(bulk orders)"]
-        Rail["🚂 Rail\n(cross-world)"]
-        Pigeon["🕊️ Pigeon\n(traditional)"]
-        Pickup["🚶 Walk-in\n(customers collect)"]
+        Tube["🔵 Pneumatic Tube<br/>(local, fast)"]
+        Drone["🛸 Drone<br/>(medium range)"]
+        Truck["🚛 Truck<br/>(bulk orders)"]
+        Rail["🚂 Rail<br/>(cross-world)"]
+        Pigeon["🕊️ Pigeon<br/>(traditional)"]
+        Pickup["🚶 Walk-in<br/>(customers collect)"]
     end
     
     Dispatch --> Methods
@@ -80,12 +80,12 @@ Six specialized stations for different shipment types:
 ```mermaid
 flowchart TB
     subgraph Stations["PACKAGING STATIONS"]
-        S1["Station 1\n📦 Standard\nCardboard, labels"]
-        S2["Station 2\n🥚 Fragile\nFoam, bubble wrap\nHANDLE WITH CARE"]
-        S3["Station 3\n👑 Premium\nVelvet-lined boxes\nGold ribbon"]
-        S4["Station 4\n📚 Bulk\nShrink-wrapped pallets"]
-        S5["Station 5\n☢️ Hazardous\nContainment vessels\nWarning labels"]
-        S6["Station 6\n🎨 Custom\nBespoke packaging\nfor special orders"]
+        S1["Station 1<br/>📦 Standard<br/>Cardboard, labels"]
+        S2["Station 2<br/>🥚 Fragile<br/>Foam, bubble wrap<br/>HANDLE WITH CARE"]
+        S3["Station 3<br/>👑 Premium<br/>Velvet-lined boxes<br/>Gold ribbon"]
+        S4["Station 4<br/>📚 Bulk<br/>Shrink-wrapped pallets"]
+        S5["Station 5<br/>☢️ Hazardous<br/>Containment vessels<br/>Warning labels"]
+        S6["Station 6<br/>🎨 Custom<br/>Bespoke packaging<br/>for special orders"]
     end
 
     style S3 fill:#f1c40f,color:#000
@@ -111,14 +111,14 @@ A brass-and-glass marvel of Victorian engineering:
 flowchart TB
     Hub["🔵 PNEUMATIC HUB"]
     
-    Hub --> T1["Tube 1\n→ Floor 1"]
-    Hub --> T2["Tube 2\n→ Floor 2"]
-    Hub --> T3["Tube 3\n→ Lobby"]
-    Hub --> T4["Tube 4\n→ Basement"]
-    Hub --> T5["Tube 5\n→ Loading Docks"]
-    Hub --> T6["Tube 6\n→ Mail Room"]
-    Hub --> T7["Tube 7\n→ THE PUB\n🍺 PRIORITY"]
-    Hub --> T8["Tube 8\n→ Rooftop"]
+    Hub --> T1["Tube 1<br/>→ Floor 1"]
+    Hub --> T2["Tube 2<br/>→ Floor 2"]
+    Hub --> T3["Tube 3<br/>→ Lobby"]
+    Hub --> T4["Tube 4<br/>→ Basement"]
+    Hub --> T5["Tube 5<br/>→ Loading Docks"]
+    Hub --> T6["Tube 6<br/>→ Mail Room"]
+    Hub --> T7["Tube 7<br/>→ THE PUB<br/>🍺 PRIORITY"]
+    Hub --> T8["Tube 8<br/>→ Rooftop"]
 
     style T7 fill:#f39c12,color:#fff
     style Hub fill:#3498db,color:#fff
@@ -147,11 +147,11 @@ A dedicated team that translates "raw insight" into "actionable knowledge":
 
 ```mermaid
 flowchart LR
-    Raw["🟡 Raw Insight\n'Correlation detected\nbetween variables\nX₇ and ∂Y/∂t'"]
+    Raw["🟡 Raw Insight<br/>'Correlation detected<br/>between variables<br/>X₇ and ∂Y/∂t'"]
     
     Raw --> Explainer["📝 Explainer"]
     
-    Explainer --> Clear["✅ Clear Insight\n'When temperature rises,\nproductivity increases.\nRecommendation: Better HVAC.'"]
+    Explainer --> Clear["✅ Clear Insight<br/>'When temperature rises,<br/>productivity increases.<br/>Recommendation: Better HVAC.'"]
 
     style Raw fill:#f1c40f,color:#000
     style Clear fill:#27ae60,color:#fff

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/loading-docks/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/loading-docks/README.md
@@ -13,17 +13,17 @@ This facility is fully integrated with the [Factorio Logistics Protocol](../../.
 ```mermaid
 flowchart LR
     subgraph Inbound["⬇️ INBOUND"]
-        B1["Bay 1\nRaw Data"]
-        B2["Bay 2\nBulk Questions"]
-        B3["Bay 3\nConfusion Tankers"]
-        B4["Bay 4\nParadox-Safe"]
+        B1["Bay 1<br/>Raw Data"]
+        B2["Bay 2<br/>Bulk Questions"]
+        B3["Bay 3<br/>Confusion Tankers"]
+        B4["Bay 4<br/>Paradox-Safe"]
     end
     
     subgraph Outbound["⬆️ OUTBOUND"]
-        B5["Bay 5\nInsight Express"]
-        B6["Bay 6\nBulk Wisdom"]
-        B7["Bay 7\nPremium/Rush"]
-        B8["Bay 8\nPigeon Post"]
+        B5["Bay 5<br/>Insight Express"]
+        B6["Bay 6<br/>Bulk Wisdom"]
+        B7["Bay 7<br/>Premium/Rush"]
+        B8["Bay 8<br/>Pigeon Post"]
     end
     
     Inbound --> Processing["🏭 To Floor 1"]
@@ -59,17 +59,17 @@ Each bay operates as a **logistic node** with chest modes:
 ```mermaid
 flowchart TB
     subgraph InboundBays["Inbound Bays (Passive Providers)"]
-        B1["Bay 1\n📦🟡 passive-provider"]
-        B2["Bay 2\n📦🟡 passive-provider"]
-        B3["Bay 3\n📦🟡 passive-provider"]
-        B4["Bay 4\n📦🔵 buffer"]
+        B1["Bay 1<br/>📦🟡 passive-provider"]
+        B2["Bay 2<br/>📦🟡 passive-provider"]
+        B3["Bay 3<br/>📦🟡 passive-provider"]
+        B4["Bay 4<br/>📦🔵 buffer"]
     end
     
     subgraph OutboundBays["Outbound Bays (Requesters)"]
-        B5["Bay 5\n📦🔴 active-provider"]
-        B6["Bay 6\n📦🟡 passive-provider"]
-        B7["Bay 7\n📦🔴 active-provider"]
-        B8["Bay 8\n📦🔴 active-provider"]
+        B5["Bay 5<br/>📦🔴 active-provider"]
+        B6["Bay 6<br/>📦🟡 passive-provider"]
+        B7["Bay 7<br/>📦🔴 active-provider"]
+        B8["Bay 8<br/>📦🔴 active-provider"]
     end
     
     InboundBays --> |"Floor 1 Intake"| OutboundBays
@@ -92,8 +92,8 @@ flowchart TB
 flowchart LR
     Bay["🏗️ Forklift Bay"]
     
-    Bay --> Dolly["👑 Dolly Doorin\nLift Queen / Fork Queen"]
-    Bay --> Fleet["Leela Forklifts ×4\nCloneable, Self-Driving"]
+    Bay --> Dolly["👑 Dolly Doorin<br/>Lift Queen / Fork Queen"]
+    Bay --> Fleet["Leela Forklifts ×4<br/>Cloneable, Self-Driving"]
 ```
 
 **Dolly Doorin** (Lift Queen) resides here when not in [Storage](../storage/). She knows where everything is. The files obey her.
@@ -113,8 +113,8 @@ Factorio-style logistic and construction drones:
 flowchart TB
     Station["🛸 Drone Charging Station"]
     
-    Station --> Logistic["Logistic Drones ×12\nCarry items between\nlogistic nodes"]
-    Station --> Construction["Construction Drones ×6\nRepair, build,\nmaintenance"]
+    Station --> Logistic["Logistic Drones ×12<br/>Carry items between<br/>logistic nodes"]
+    Station --> Construction["Construction Drones ×6<br/>Repair, build,<br/>maintenance"]
 ```
 
 | Type | Count | Status | Recyclable |
@@ -130,9 +130,9 @@ For historical/fantasy integration:
 flowchart TB
     House["🐴 Carriage House"]
     
-    House --> Carriage["Horse-Drawn Carriages\nD&D compatible"]
+    House --> Carriage["Horse-Drawn Carriages<br/>D&D compatible"]
     House --> Horses["Draft & Riding Horses"]
-    House --> Jareth["Old Jareth\nStable Master"]
+    House --> Jareth["Old Jareth<br/>Stable Master"]
 ```
 
 *"For when the destination is more important than the speed."* — Old Jareth
@@ -145,11 +145,11 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    LOG1["📹 LOG1\nFirst Eye"]
+    LOG1["📹 LOG1<br/>First Eye"]
     
     LOG1 --> |"watches"| Docks["Loading Docks"]
     Docks --> |"observed by"| Pipeline["Video Pipeline"]
-    Pipeline --> |"generates"| Insights["Insights about\nlogistics operations"]
+    Pipeline --> |"generates"| Insights["Insights about<br/>logistics operations"]
 ```
 
 | Detection | Last Hour |

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/lobby/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/lobby/README.md
@@ -12,12 +12,12 @@ The **Lobby** is clean, professional, and quietly impressive. The Leela logo glo
 flowchart TB
     subgraph Building["🏭 LEELA MANUFACTURING INTELLIGENCE"]
         direction TB
-        Roof["🌿 Rooftop\nGarden & Drones"]
-        F3["Floor 3\n📦 Shipping"]
-        F2["Floor 2\n🔥 Factory"]
-        F1["Floor 1\n🔄 Intake"]
-        Lobby["Ground\n🚪 Lobby ← YOU ARE HERE"]
-        Basement["Basement\n🔬 R&D"]
+        Roof["🌿 Rooftop<br/>Garden & Drones"]
+        F3["Floor 3<br/>📦 Shipping"]
+        F2["Floor 2<br/>🔥 Factory"]
+        F1["Floor 1<br/>🔄 Intake"]
+        Lobby["Ground<br/>🚪 Lobby ← YOU ARE HERE"]
+        Basement["Basement<br/>🔬 R&D"]
     end
     
     Roof --> F3 --> F2 --> F1 --> Lobby --> Basement
@@ -50,7 +50,7 @@ flowchart TB
 ```mermaid
 flowchart LR
     Visitor["👤 Visitor"] --> Reception["🛎️ Reception Desk"]
-    Reception --> Help["How can we\nhelp you today?"]
+    Reception --> Help["How can we<br/>help you today?"]
     Help --> Directory["📋 Directory"]
     Help --> Elevator["🛗 Elevator"]
     Help --> Guide["🚶 Guided Tour"]
@@ -100,7 +100,7 @@ flowchart TB
     Elevator --> F2["2: Factory"]
     Elevator --> F1["1: Intake"]
     Elevator --> Lobby["G: Lobby"]
-    Elevator --> B["B: Basement\n🔒 Clearance Required"]
+    Elevator --> B["B: Basement<br/>🔒 Clearance Required"]
 
     style B fill:#e74c3c,color:#fff
 ```

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/mail-room/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/mail-room/README.md
@@ -13,16 +13,16 @@ Fully integrated with the [Postal System](../../../../skills/postal/).
 ```mermaid
 flowchart TB
     subgraph MailRoom["📮 MAIL ROOM"]
-        Inbox["📥 General Inbox\nLetters, texts, packages"]
-        Outbox["📤 General Outbox\nActive provider mode"]
-        Sorting["📬 Sorting Bins\nBy destination type"]
+        Inbox["📥 General Inbox<br/>Letters, texts, packages"]
+        Outbox["📤 General Outbox<br/>Active provider mode"]
+        Sorting["📬 Sorting Bins<br/>By destination type"]
     end
     
     subgraph Methods["Delivery Methods"]
-        Postal["📮 Postal\nInternal transit"]
-        Drone["🛸 Drone\nLane Neverending"]
-        Pigeon["🕊️ Pigeon\nTraditional"]
-        Pneumatic["🔵 Pneumatic\nAll floors + pub"]
+        Postal["📮 Postal<br/>Internal transit"]
+        Drone["🛸 Drone<br/>Lane Neverending"]
+        Pigeon["🕊️ Pigeon<br/>Traditional"]
+        Pneumatic["🔵 Pneumatic<br/>All floors + pub"]
     end
     
     Inbox --> Sorting
@@ -73,14 +73,14 @@ The pub tube is the fastest. Some insights are best delivered with a pint.
 flowchart LR
     Bank["📞 Phone Bank"]
     
-    Bank --> Text["📱 Texting\n(modern)"]
-    Bank --> Voice["☎️ Voice\n(traditional)"]
-    Bank --> Hotlines["🔴 Hotlines\n(specialized)"]
+    Bank --> Text["📱 Texting<br/>(modern)"]
+    Bank --> Voice["☎️ Voice<br/>(traditional)"]
+    Bank --> Hotlines["🔴 Hotlines<br/>(specialized)"]
     
     subgraph Hotlines_Detail["Hotlines"]
-        H1["Wisdom Hotline\n(answers slowly)"]
-        H2["Paradox Support\n(may or may not help)"]
-        H3["Emergency\n(actual emergencies)"]
+        H1["Wisdom Hotline<br/>(answers slowly)"]
+        H2["Paradox Support<br/>(may or may not help)"]
+        H3["Emergency<br/>(actual emergencies)"]
     end
     
     Hotlines --> Hotlines_Detail
@@ -103,9 +103,9 @@ For traditional correspondence:
 flowchart LR
     Loft["🕊️ Pigeon Loft"]
     
-    Loft --> Standard["Standard Pigeons\n(local delivery)"]
-    Loft --> Premium["Premium Pigeons\n(express, trained)"]
-    Loft --> Enlightened["Enlightened Pigeons\n(carry wisdom, rare)"]
+    Loft --> Standard["Standard Pigeons<br/>(local delivery)"]
+    Loft --> Premium["Premium Pigeons<br/>(express, trained)"]
+    Loft --> Enlightened["Enlightened Pigeons<br/>(carry wisdom, rare)"]
 ```
 
 | Pigeon Type | Range | Capacity | Availability |
@@ -124,13 +124,13 @@ Incoming mail is automatically sorted:
 flowchart TB
     Incoming["📥 Incoming Mail"]
     
-    Incoming --> Sort{"Sort by\nType"}
+    Incoming --> Sort{"Sort by<br/>Type"}
     
-    Sort --> Internal["🏭 Internal\n(same building)"]
-    Sort --> Local["🏘️ Local\n(Lane Neverending)"]
-    Sort --> Regional["🌆 Regional\n(greater area)"]
-    Sort --> External["🌍 External\n(everywhere else)"]
-    Sort --> Weird["❓ Weird\n(ask the Archivist)"]
+    Sort --> Internal["🏭 Internal<br/>(same building)"]
+    Sort --> Local["🏘️ Local<br/>(Lane Neverending)"]
+    Sort --> Regional["🌆 Regional<br/>(greater area)"]
+    Sort --> External["🌍 External<br/>(everywhere else)"]
+    Sort --> Weird["❓ Weird<br/>(ask the Archivist)"]
 
     style Weird fill:#9b59b6,color:#fff
 ```

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/rooftop/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/rooftop/README.md
@@ -13,18 +13,18 @@ This is where workers come to think. Where Eventually the Tortoise holds court. 
 ```mermaid
 flowchart TB
     subgraph Garden["🌿 ROOFTOP GARDEN"]
-        Tree["🌳 The Origin Tree\n(shouldn't exist here)"]
-        Herbs["🌿 Herb Spiral\nrosemary, lavender,\nthyme, ideas"]
-        Veggies["🥬 Vegetable Beds\ntomatoes, peppers,\ninsights"]
-        Flowers["🌸 Flower Patches\naesthetic + functional"]
-        Mushroom["🍄 Mushroom Corner\nshaded, mysterious\nDON'T EAT THESE"]
-        Compost["♻️ Compost Bins\nrecycling failed insights\ninto future potential"]
+        Tree["🌳 The Origin Tree<br/>(shouldn't exist here)"]
+        Herbs["🌿 Herb Spiral<br/>rosemary, lavender,<br/>thyme, ideas"]
+        Veggies["🥬 Vegetable Beds<br/>tomatoes, peppers,<br/>insights"]
+        Flowers["🌸 Flower Patches<br/>aesthetic + functional"]
+        Mushroom["🍄 Mushroom Corner<br/>shaded, mysterious<br/>DON'T EAT THESE"]
+        Compost["♻️ Compost Bins<br/>recycling failed insights<br/>into future potential"]
     end
     
     subgraph Facilities["Facilities"]
-        Turtle["🐢 Eventually's\nSunny Corner"]
-        Scope["🔭 Observation\nDeck"]
-        Pads["🛸 Drone Pads\n×6"]
+        Turtle["🐢 Eventually's<br/>Sunny Corner"]
+        Scope["🔭 Observation<br/>Deck"]
+        Pads["🛸 Drone Pads<br/>×6"]
     end
 
     style Tree fill:#228B22,color:#fff
@@ -39,11 +39,11 @@ An oak that shouldn't exist on a rooftop. Its trunk is thick, its branches sprea
 
 ```mermaid
 flowchart TB
-    Origin["🌳 The Origin Tree\n(somewhere ancient)"]
+    Origin["🌳 The Origin Tree<br/>(somewhere ancient)"]
     
-    Origin --> |"cutting taken"| Rooftop["🌱 Rooftop Tree\n(Leela Manufacturing)"]
-    Origin --> |"cutting taken"| Garden["🌱 Back Garden Tree\n(The Pub)"]
-    Origin --> |"cutting taken"| Other["🌱 Other locations\n(unknown)"]
+    Origin --> |"cutting taken"| Rooftop["🌱 Rooftop Tree<br/>(Leela Manufacturing)"]
+    Origin --> |"cutting taken"| Garden["🌱 Back Garden Tree<br/>(The Pub)"]
+    Origin --> |"cutting taken"| Other["🌱 Other locations<br/>(unknown)"]
 
     style Origin fill:#228B22,color:#fff
 ```
@@ -62,8 +62,8 @@ An ancient wisdom tortoise who has been here longer than anyone remembers.
 
 ```mermaid
 flowchart LR
-    Question["❓ Your Question"] --> Wait["⏳ Wait...\n(hours, sometimes)"]
-    Wait --> Answer["💡 Wisdom\n(always worth it)"]
+    Question["❓ Your Question"] --> Wait["⏳ Wait...<br/>(hours, sometimes)"]
+    Wait --> Answer["💡 Wisdom<br/>(always worth it)"]
 
     style Wait fill:#DEB887,color:#000
 ```
@@ -90,12 +90,12 @@ Six hexagonal landing zones near the edge of the roof:
 ```mermaid
 flowchart TB
     subgraph Pads["🛸 DRONE PADS"]
-        P1["Pad 1\n🟢 Clear"]
-        P2["Pad 2\n🟡 Landing"]
-        P3["Pad 3\n🔴 Occupied"]
-        P4["Pad 4\n🟢 Clear"]
-        P5["Pad 5\n🟢 Clear"]
-        P6["Pad 6\n🟡 Launching"]
+        P1["Pad 1<br/>🟢 Clear"]
+        P2["Pad 2<br/>🟡 Landing"]
+        P3["Pad 3<br/>🔴 Occupied"]
+        P4["Pad 4<br/>🟢 Clear"]
+        P5["Pad 5<br/>🟢 Clear"]
+        P6["Pad 6<br/>🟡 Launching"]
     end
     
     Pads --> Routes
@@ -128,10 +128,10 @@ A raised platform with the best view of Lane Neverending.
 flowchart LR
     Telescope["🔭 Telescope"]
     
-    Telescope --> Pub["🍺 The Pub\n(waves back!)"]
-    Telescope --> Street["🛣️ Lane Neverending\n(east to west)"]
-    Telescope --> Sky["🌟 Night Sky\n(LLOOOOMM Constellation)"]
-    Telescope --> Other["🏢 Other Buildings\n(the neighborhood)"]
+    Telescope --> Pub["🍺 The Pub<br/>(waves back!)"]
+    Telescope --> Street["🛣️ Lane Neverending<br/>(east to west)"]
+    Telescope --> Sky["🌟 Night Sky<br/>(LLOOOOMM Constellation)"]
+    Telescope --> Other["🏢 Other Buildings<br/>(the neighborhood)"]
 ```
 
 The pub's rooftop also has a telescope. The two occasionally wave at each other.

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/storage/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/storage/README.md
@@ -13,16 +13,16 @@ This is **prototype-based design** made physical. Everything here is a template.
 ```mermaid
 flowchart LR
     subgraph Input["Request"]
-        Request["'I need a\nwooden crate'"]
+        Request["'I need a<br/>wooden crate'"]
     end
     
     Request --> Terminal["🖥️ Cloning Terminal"]
     
     Terminal --> Search["Search prototypes"]
-    Search --> Aisle["Aisle A:\nWooden Containers"]
-    Aisle --> Prototype["wooden-crate\nprototype"]
+    Search --> Aisle["Aisle A:<br/>Wooden Containers"]
+    Aisle --> Prototype["wooden-crate<br/>prototype"]
     Prototype --> Clone["📦 CLONE"]
-    Clone --> Output["Fresh crate\n(your instance)"]
+    Clone --> Output["Fresh crate<br/>(your instance)"]
 ```
 
 **Commands:**
@@ -38,12 +38,12 @@ flowchart LR
 ```mermaid
 flowchart TB
     subgraph Storage["📦 STORAGE COMPLEX"]
-        A["🪵 Aisle A\nWooden Containers"]
-        B["🔩 Aisle B\nMetal Containers"]
-        C["👜 Aisle C\nSoft Containers"]
-        D["✨ Aisle D\nSpecial Containers"]
-        E["🖼️ Aisle E\nDisplay Containers"]
-        L["🏭 Aisle L\nLeela Logistics"]
+        A["🪵 Aisle A<br/>Wooden Containers"]
+        B["🔩 Aisle B<br/>Metal Containers"]
+        C["👜 Aisle C<br/>Soft Containers"]
+        D["✨ Aisle D<br/>Special Containers"]
+        E["🖼️ Aisle E<br/>Display Containers"]
+        L["🏭 Aisle L<br/>Leela Logistics"]
     end
     
     Central["🔬 Cloning Station"]
@@ -76,10 +76,10 @@ flowchart TB
 ```mermaid
 flowchart LR
     subgraph AisleA["🪵 AISLE A"]
-        Crate["wooden-crate\n📦 Standard shipping"]
-        Barrel["ale-barrel\n🛢️ Liquid storage"]
-        Chest["treasure-chest\n💰 Valuables"]
-        Box["simple-box\n📦 Basic storage"]
+        Crate["wooden-crate<br/>📦 Standard shipping"]
+        Barrel["ale-barrel<br/>🛢️ Liquid storage"]
+        Chest["treasure-chest<br/>💰 Valuables"]
+        Box["simple-box<br/>📦 Basic storage"]
     end
 
     style AisleA fill:#8B4513,color:#fff
@@ -101,12 +101,12 @@ flowchart LR
 ```mermaid
 flowchart TB
     subgraph AisleD["✨ AISLE D — SPECIAL"]
-        Paradox["paradox-box\n🔄 Contents uncertain"]
-        Schrodinger["schrodinger-box\n😺 Superposition storage"]
-        Tesseract["tesseract-box\n4️⃣ 4D storage"]
-        Russell["russells-set\n❓ Paradox incarnate"]
-        Cons["cons-cell\n(car . cdr)"]
-        QuadTree["quad-tree\n📐 2D spatial"]
+        Paradox["paradox-box<br/>🔄 Contents uncertain"]
+        Schrodinger["schrodinger-box<br/>😺 Superposition storage"]
+        Tesseract["tesseract-box<br/>4️⃣ 4D storage"]
+        Russell["russells-set<br/>❓ Paradox incarnate"]
+        Cons["cons-cell<br/>(car . cdr)"]
+        QuadTree["quad-tree<br/>📐 2D spatial"]
     end
 
     style AisleD fill:#9400D3,color:#fff
@@ -147,17 +147,17 @@ Factorio-style logistics containers with special modes:
 ```mermaid
 flowchart TB
     subgraph AisleL["🏭 AISLE L — LEELA LOGISTICS"]
-        Storage["leela-storage-chest\n📦 General storage"]
-        Passive["leela-passive-provider\n📦🟡 Available for bots"]
-        Active["leela-active-provider\n📦🔴 PUSH OUT!"]
-        Requester["leela-requester\n📦🟣 Requests items"]
-        Buffer["leela-buffer\n📦🔵 Smart buffer"]
+        Storage["leela-storage-chest<br/>📦 General storage"]
+        Passive["leela-passive-provider<br/>📦🟡 Available for bots"]
+        Active["leela-active-provider<br/>📦🔴 PUSH OUT!"]
+        Requester["leela-requester<br/>📦🟣 Requests items"]
+        Buffer["leela-buffer<br/>📦🔵 Smart buffer"]
     end
     
     subgraph Special["SPECIAL CONTAINERS"]
-        DevNull["/dev/null-box\n🕳️ Destroys contents"]
-        Dumpster["burning-dumpster\n🔥 Continuously on fire"]
-        Infinite["infinite-source\n♾️ Never empties"]
+        DevNull["/dev/null-box<br/>🕳️ Destroys contents"]
+        Dumpster["burning-dumpster<br/>🔥 Continuously on fire"]
+        Infinite["infinite-source<br/>♾️ Never empties"]
     end
 
     style DevNull fill:#000,color:#fff
@@ -218,13 +218,13 @@ Everything in Storage is a **prototype**, not an instance:
 
 ```mermaid
 flowchart TB
-    Proto["📋 Prototype\n(template)"]
+    Proto["📋 Prototype<br/>(template)"]
     
     Proto --> |"clone()"| I1["📦 Instance 1"]
     Proto --> |"clone()"| I2["📦 Instance 2"]
     Proto --> |"clone()"| I3["📦 Instance 3"]
     
-    I1 --> |"customize"| I1a["📦 Modified\nInstance 1"]
+    I1 --> |"customize"| I1a["📦 Modified<br/>Instance 1"]
 ```
 
 From the **Self** programming language:

--- a/examples/adventure-4/street/lane-neverending/leela-manufacturing/warehouse-23/README.md
+++ b/examples/adventure-4/street/lane-neverending/leela-manufacturing/warehouse-23/README.md
@@ -12,20 +12,20 @@ If you've seen *Raiders of the Lost Ark*, you know what this is.
 
 ```mermaid
 flowchart TB
-    Entry["🚪 Entry\n(clearance required)"]
+    Entry["🚪 Entry<br/>(clearance required)"]
     
-    Entry --> Hall["Main Hall\nCrates as far as\nyou can see"]
+    Entry --> Hall["Main Hall<br/>Crates as far as<br/>you can see"]
     
-    Hall --> Deep["Deeper Stacks\n(geometry uncertain)"]
-    Deep --> Deeper["Even Deeper\n(don't go alone)"]
+    Hall --> Deep["Deeper Stacks<br/>(geometry uncertain)"]
+    Deep --> Deeper["Even Deeper<br/>(don't go alone)"]
     Deeper --> Unknown["???"]
     
     subgraph Notable["Notable Crates"]
-        Ark["📦 The Ark\n(don't open)"]
-        Grail["📦 The Grail\n(choose wisely)"]
-        Pandora["📦 Pandora's Box\n(hope remains)"]
-        Ring["📦 The One Ring\n(destroy it)"]
-        Question["📦 The '?' Container\n(from FAC1 incident)"]
+        Ark["📦 The Ark<br/>(don't open)"]
+        Grail["📦 The Grail<br/>(choose wisely)"]
+        Pandora["📦 Pandora's Box<br/>(hope remains)"]
+        Ring["📦 The One Ring<br/>(destroy it)"]
+        Question["📦 The '?' Container<br/>(from FAC1 incident)"]
     end
     
     Hall --> Notable
@@ -40,7 +40,7 @@ flowchart TB
 ```mermaid
 flowchart LR
     You["👤 You"] --> |"'Where is...?'"| Archivist["🧓 The Archivist"]
-    Archivist --> |"consults memory"| Answer["'Row 47,281.\nShelf 3.\nDon't touch the\none next to it.'"]
+    Archivist --> |"consults memory"| Answer["'Row 47,281.<br/>Shelf 3.<br/>Don't touch the<br/>one next to it.'"]
 ```
 
 **The Archivist** knows where every crate is. They've been here longer than the warehouse has existed, which is architecturally concerning.
@@ -86,14 +86,14 @@ That container is now here. It has been here since that day.
 
 ```mermaid
 flowchart TB
-    Outside["📐 Outside:\n2,000 sq ft building"]
-    Inside["📐 Inside:\n??? (measurement fails)"]
+    Outside["📐 Outside:<br/>2,000 sq ft building"]
+    Inside["📐 Inside:<br/>??? (measurement fails)"]
     
     Outside --> |"step through door"| Inside
     
-    Inside --> |"walk 10 minutes"| Still["Still inside\n(rows continue)"]
-    Still --> |"walk 30 minutes"| Deeper["Deeper\n(lighting changes)"]
-    Deeper --> |"walk 1 hour"| Return["Somehow back\nat entrance"]
+    Inside --> |"walk 10 minutes"| Still["Still inside<br/>(rows continue)"]
+    Still --> |"walk 30 minutes"| Deeper["Deeper<br/>(lighting changes)"]
+    Deeper --> |"walk 1 hour"| Return["Somehow back<br/>at entrance"]
 
     style Inside fill:#34495e,color:#fff
 ```
@@ -112,12 +112,12 @@ The warehouse is non-Euclidean. The space inside exceeds the space outside. This
 
 ```mermaid
 flowchart LR
-    Request["📋 Request\nAccess"]
+    Request["📋 Request<br/>Access"]
     
-    Request --> Level["Security Level\ncheck"]
-    Level --> Purpose["Purpose\nverification"]
-    Purpose --> Archivist["Archivist\napproval"]
-    Archivist --> Access["🔓 Access\nGranted"]
+    Request --> Level["Security Level<br/>check"]
+    Level --> Purpose["Purpose<br/>verification"]
+    Purpose --> Archivist["Archivist<br/>approval"]
+    Archivist --> Access["🔓 Access<br/>Granted"]
     
     Level --> |"insufficient"| Denied["🚫 Denied"]
     Purpose --> |"suspicious"| Denied

--- a/examples/adventure-4/street/lane-neverending/w1/README.md
+++ b/examples/adventure-4/street/lane-neverending/w1/README.md
@@ -11,15 +11,15 @@
 ```mermaid
 flowchart TB
     subgraph North["NORTH SIDE"]
-        ACME["🏚️ ACME SURPLUS\n4 Lane Neverending\n(closed, painted tunnel)"]
+        ACME["🏚️ ACME SURPLUS<br/>4 Lane Neverending<br/>(closed, painted tunnel)"]
     end
     
     subgraph Street["═══ LANE NEVERENDING ═══"]
-        W2["← w2"] --> W1["W1\nYou Are Here"] --> Center["center →"]
+        W2["← w2"] --> W1["W1<br/>You Are Here"] --> Center["center →"]
     end
     
     subgraph South["SOUTH SIDE"]
-        Leela["🏭 LEELA MANUFACTURING\n5 Lane Neverending\n(thriving)"]
+        Leela["🏭 LEELA MANUFACTURING<br/>5 Lane Neverending<br/>(thriving)"]
     end
 
     style ACME fill:#7f8c8d,color:#fff
@@ -46,11 +46,11 @@ flowchart TB
 flowchart LR
     subgraph ACME["🏚️ ACME SURPLUS"]
         Window["Dusty windows"]
-        Anvil["Display anvil\n(not for sale)"]
-        Tunnel["🎨 PAINTED TUNNEL\n(DO NOT RUN)"]
+        Anvil["Display anvil<br/>(not for sale)"]
+        Tunnel["🎨 PAINTED TUNNEL<br/>(DO NOT RUN)"]
     end
     
-    You["🏃 You"] --> |"sprint at tunnel"| THWACK["💥 THWACK\n(solid plywood)"]
+    You["🏃 You"] --> |"sprint at tunnel"| THWACK["💥 THWACK<br/>(solid plywood)"]
     Delivery["🚚 ACME Delivery"] --> |"walks through"| Tunnel
 
     style Tunnel fill:#9b59b6,color:#fff

--- a/examples/adventure-4/street/lane-neverending/w2/README.md
+++ b/examples/adventure-4/street/lane-neverending/w2/README.md
@@ -10,7 +10,7 @@
 
 ```mermaid
 flowchart LR
-    W3["← w3"] --> W2["W2\nYou Are Here"]
+    W3["← w3"] --> W2["W2<br/>You Are Here"]
     W2 --> W1["w1 →"]
     
     subgraph Landmarks["This Block"]

--- a/examples/adventure-4/street/lane-neverending/w3/README.md
+++ b/examples/adventure-4/street/lane-neverending/w3/README.md
@@ -10,7 +10,7 @@
 
 ```mermaid
 flowchart LR
-    E3["← e3\n(east side!)"] --> |"THE LOOP!"| W3["W3\nYou Are Here"]
+    E3["← e3<br/>(east side!)"] --> |"THE LOOP!"| W3["W3<br/>You Are Here"]
     W3 --> W2["w2 →"]
     
     style W3 fill:#9b59b6,color:#fff


### PR DESCRIPTION
GitHub's Mermaid renderer requires <br/> for line breaks in node labels, not \n which renders literally as "\n".

Fixed 19 README files in adventure-4.