### PR TITLE
Fix broken relative links to style guide

### DIFF
--- a/examples/adventure-4/pub/attic/SLIDESHOW.md
+++ b/examples/adventure-4/pub/attic/SLIDESHOW.md
@@ -138,7 +138,7 @@ A visual tour through the attic, rendered in seven legendary art styles — from
 
 **Prompt Coherence:** 93% — Hall of Fame worthy.
 
-📎 **Files:** [Prompt Sidecar](attic-2026-01-19-05-27-00-jaquays-tribute.yml) | [Mining Analysis](attic-2026-01-19-05-27-00-jaquays-tribute-mined.yml) | [Style Guide](../../skills/visualizer/styles/jennell-jaquays.yml)
+📎 **Files:** [Prompt Sidecar](attic-2026-01-19-05-27-00-jaquays-tribute.yml) | [Mining Analysis](attic-2026-01-19-05-27-00-jaquays-tribute-mined.yml) | [Style Guide](../../../../skills/visualizer/styles/jennell-jaquays.yml)
 
 ---
 
@@ -383,7 +383,7 @@ This applies to visual art too. The tribute image has:
 
 The Jennell Jaquays style analysis is now available as a reusable context file:
 
-**[`skills/visualizer/styles/jennell-jaquays.yml`](../../skills/visualizer/styles/jennell-jaquays.yml)**
+**[`skills/visualizer/styles/jennell-jaquays.yml`](../../../../skills/visualizer/styles/jennell-jaquays.yml)**
 
 Include this file in any `visualize.py` generation to apply Jaquays' distinctive style:
 

--- a/examples/adventure-4/pub/attic/attic-2026-01-19-05-27-00-jaquays-tribute.yml
+++ b/examples/adventure-4/pub/attic/attic-2026-01-19-05-27-00-jaquays-tribute.yml
@@ -16,7 +16,7 @@ sources:
   - probability-goggles.yml
   - recursion-lantern.yml
   - box-of-edge-cases.yml
-  - ../../skills/visualizer/styles/jennell-jaquays.yml
+  - ../../../../skills/visualizer/styles/jennell-jaquays.yml
 
 # === GENERATION PARAMETERS ===
 generation:
@@ -112,7 +112,7 @@ prompt: |
 
 # === JAQUAYS STYLE GUIDE (for regeneration) ===
 # Include this file as context to maintain style consistency
-style_reference: "../../skills/visualizer/styles/jennell-jaquays.yml"
+style_reference: "../../../../skills/visualizer/styles/jennell-jaquays.yml"
 
 style_summary: |
   JENNELL JAQUAYS STYLE — JUDGES GUILD PERIOD


### PR DESCRIPTION
## Fix Broken Links

Links from `examples/adventure-4/pub/attic/` to `skills/visualizer/styles/` need 4 levels up (`../../../../`) not 2 levels (`../../`).

### Files Fixed

| File | Issue |
|------|-------|
| `SLIDESHOW.md` | 2 links to jennell-jaquays.yml |
| `attic-2026-01-19-05-27-00-jaquays-tribute.yml` | 2 source references |

### The Math

```
examples/adventure-4/pub/attic/SLIDESHOW.md
    ↑       ↑         ↑    ↑
    4       3         2    1   ← levels to go up
```

Tiny fix, big difference.