### PR TITLE
Fix broken Jaquays style guide links in attic SLIDESHOW

### DIFF
--- a/examples/adventure-4/pub/attic/dusty-attic-art-styles/README.md
+++ b/examples/adventure-4/pub/attic/dusty-attic-art-styles/README.md
@@ -74,7 +74,7 @@ The same attic. The same mysteries. Seven ways of seeing.
 
 Her name became a verb: "Jaquaysing the dungeon" means creating scenarios with myriad paths, non-linear and multi-solution. The tribute image doesn't just copy her style — it embodies her philosophy: multiple visual paths, nested spaces, creatures as characters.
 
-**[→ Jaquays Style Guide](../../../../skills/visualizer/styles/jennell-jaquays.yml)**
+**[→ Jaquays Style Guide](../../../../../skills/visualizer/styles/jennell-jaquays.yml)**
 
 ---
 

--- a/examples/adventure-4/pub/attic/dusty-attic-art-styles/SLIDESHOW.md
+++ b/examples/adventure-4/pub/attic/dusty-attic-art-styles/SLIDESHOW.md
@@ -146,7 +146,7 @@ A visual tour through the attic, rendered in seven legendary art styles — from
 
 **Prompt Coherence:** 93% — Hall of Fame worthy.
 
-📎 **Files:** [Prompt Sidecar](attic-2026-01-19-05-27-00-jaquays-tribute.yml) | [Mining Analysis](attic-2026-01-19-05-27-00-jaquays-tribute-mined.yml) | [Style Guide](../../../../skills/visualizer/styles/jennell-jaquays.yml)
+📎 **Files:** [Prompt Sidecar](attic-2026-01-19-05-27-00-jaquays-tribute.yml) | [Mining Analysis](attic-2026-01-19-05-27-00-jaquays-tribute-mined.yml) | [Style Guide](../../../../../skills/visualizer/styles/jennell-jaquays.yml)
 
 ---
 
@@ -391,7 +391,7 @@ This applies to visual art too. The tribute image has:
 
 The Jennell Jaquays style analysis is now available as a reusable context file:
 
-**[`skills/visualizer/styles/jennell-jaquays.yml`](../../../../skills/visualizer/styles/jennell-jaquays.yml)**
+**[`skills/visualizer/styles/jennell-jaquays.yml`](../../../../../skills/visualizer/styles/jennell-jaquays.yml)**
 
 Include this file in any `visualize.py` generation to apply Jaquays' distinctive style:
 

--- a/examples/adventure-4/pub/attic/dusty-attic-art-styles/attic-2026-01-19-05-27-00-jaquays-tribute.yml
+++ b/examples/adventure-4/pub/attic/dusty-attic-art-styles/attic-2026-01-19-05-27-00-jaquays-tribute.yml
@@ -16,7 +16,7 @@ sources:
   - probability-goggles.yml
   - recursion-lantern.yml
   - box-of-edge-cases.yml
-  - ../../../../skills/visualizer/styles/jennell-jaquays.yml
+  - ../../../../../skills/visualizer/styles/jennell-jaquays.yml
 
 # === GENERATION PARAMETERS ===
 generation:
@@ -112,7 +112,7 @@ prompt: |
 
 # === JAQUAYS STYLE GUIDE (for regeneration) ===
 # Include this file as context to maintain style consistency
-style_reference: "../../../../skills/visualizer/styles/jennell-jaquays.yml"
+style_reference: "../../../../../skills/visualizer/styles/jennell-jaquays.yml"
 
 style_summary: |
   JENNELL JAQUAYS STYLE — JUDGES GUILD PERIOD


### PR DESCRIPTION
Path was 4 levels up (../../../../) but needs 5 levels (../../../../../) to reach repo root from examples/adventure-4/pub/attic/dusty-attic-art-styles/