### PR TITLE
feat: improve skill scores for 5 core MOOLLM skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/abstract/SKILL.md
+++ b/skills/abstract/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: abstract
+description: "Personification protocol for giving voice to concepts, documents, rooms, and collectives. Defines ethics for faithful representation, simulation entry patterns, and combination rules. Use when personifying ideas as characters, letting documents speak, or creating teaching mascots."
+---
+
 # Abstract — Protocol Specification
 
 > Ideas with faces, thoughts that speak, rooms with views.

--- a/skills/adventure/SKILL.md
+++ b/skills/adventure/SKILL.md
@@ -1,23 +1,21 @@
 ---
 name: adventure
-description: Room-based exploration with narrative evidence collection
-allowed-tools:
-  - read_file
-  - write_file
-  - list_dir
-tier: 1
-protocol: ADVENTURE
-lineage: "Colossal Cave, Zork, MUD, LambdaMOO"
-inherits: simulation
-related: [room, character, incarnation, simulation, card, memory-palace, world-generation, debugging, sniffable-python]
-tags: [moollm, exploration, narrative, investigation, game, interactive-fiction]
-templates:
-  - file: ADVENTURE.yml.tmpl
-    purpose: Complete adventure state (inherits simulation properties)
-  - file: LOG.md.tmpl
-    purpose: Summary table (turns, locations, files changed)
-  - file: TRANSCRIPT.md.tmpl
-    purpose: Pure narration (story, YAML objects, mermaid diagrams)
+description: "Room-based exploration with narrative evidence collection. Turns directories into quest rooms with player state, inventory, and dungeon master narration. Use when building interactive fiction, codebase archaeology quests, or any simulation where navigation is investigation."
+allowed-tools: "read_file, write_file, list_dir"
+metadata:
+  tier: 1
+  protocol: ADVENTURE
+  lineage: "Colossal Cave, Zork, MUD, LambdaMOO"
+  inherits: simulation
+  related: [room, character, incarnation, simulation, card, memory-palace, world-generation, debugging, sniffable-python]
+  tags: [moollm, exploration, narrative, investigation, game, interactive-fiction]
+  templates:
+    - file: ADVENTURE.yml.tmpl
+      purpose: Complete adventure state (inherits simulation properties)
+    - file: LOG.md.tmpl
+      purpose: Summary table (turns, locations, files changed)
+    - file: TRANSCRIPT.md.tmpl
+      purpose: Pure narration (story, YAML objects, mermaid diagrams)
 ---
 
 # Adventure

--- a/skills/cat/SKILL.md
+++ b/skills/cat/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: cat
-description: Feline interactions, buffs, and relationship building
-allowed-tools:
-  - read_file
-  - write_file
-tier: 1
-protocol: CAT
-origin: "Tamagotchi, Harvest Moon, Stardew Valley, real cats"
-related: [dog, character, buff, mind-mirror, room]
-tags: [moollm, pet, companion, interaction, buff, feline]
+description: "Feline interaction system with touch, play, and communication mechanics. Calculates outcomes using Sims-style traits, tracks relationship levels from Stranger to Soulmate, and applies terpene-based buffs. Use when simulating cat NPCs, pet companion interactions, or animal relationship building."
+allowed-tools: "read_file, write_file"
+metadata:
+  tier: 1
+  protocol: CAT
+  origin: "Tamagotchi, Harvest Moon, Stardew Valley, real cats"
+  related: [dog, character, buff, mind-mirror, room]
+  tags: [moollm, pet, companion, interaction, buff, feline]
 ---
 
 # CAT — The Feline Interaction Skill

--- a/skills/character/SKILL.md
+++ b/skills/character/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: character
-description: Core patterns for all characters — home, location, relationships, inventory
-allowed-tools:
-  - read_file
-  - write_file
-tier: 1
-protocol: CHARACTER-AS-ENTITY
-related: [cat, dog, society-of-mind, persona, room, buff, needs, mind-mirror, incarnation, party]
-tags: [moollm, entity, location, relationships, inventory, identity]
+description: "Core entity patterns for players, NPCs, and companions. Defines home vs location distinction, canonical state ownership, Sims-style traits, bidirectional inventory with refs and objects, and relationship tracking from Stranger to Soulmate. Use when creating characters, managing inventory, or handling entity state in a MOOLLM world."
+allowed-tools: "read_file, write_file"
+metadata:
+  tier: 1
+  protocol: CHARACTER-AS-ENTITY
+  related: [cat, dog, society-of-mind, persona, room, buff, needs, mind-mirror, incarnation, party]
+  tags: [moollm, entity, location, relationships, inventory, identity]
 ---
 
 # Character

--- a/skills/room/SKILL.md
+++ b/skills/room/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: room
-description: "Rooms are intertwingled navigable activation context maps. Entering = calling. Exiting = returning."
+description: "Directories as navigable cognitive spaces with activation context. Maps filesystem structure to rooms with exits, regions, objects, inventories, and spatial coordinates. Use when navigating worlds, creating rooms, managing spatial layouts, or building data-flow pipelines between directory nodes."
 license: MIT
-tier: 1
-allowed-tools:
-  - read_file
-  - write_file
-related: [card, container, exit, object, memory-palace, adventure, character, data-flow, multi-presence, plain-text]
-tags: [moollm, navigation, space, directory, moo, adventure]
+allowed-tools: "read_file, write_file"
+metadata:
+  tier: 1
+  related: [card, container, exit, object, memory-palace, adventure, character, data-flow, multi-presence, plain-text]
+  tags: [moollm, navigation, space, directory, moo, adventure]
 ---
 
 # Room
@@ -306,152 +305,27 @@ Navigation can use coordinates:
 
 **Not all rooms need coordinates.** Abstract spaces can exist outside world-space.
 
-## Vehicles: Portable Rooms That Move
+## Vehicles: Portable Rooms
 
-A **vehicle** is a room you can embark, drive, and disembark.
-
-```yaml
-# vehicle-tent.yml
-room:
-  name: "Research Tent"
-  is_vehicle: true
-  world_position: {x: 5, y: 12}  # Changes when you drive
-```
+A **vehicle** is a room with `is_vehicle: true` — embark, drive, disembark. Includes Logo-style turtle navigation (RIDE, FORWARD, RIGHT) and Sims-style pie menu interactions where objects advertise scored actions.
 
 | Command | Effect |
 |---------|--------|
-| `EMBARK tent` | Enter the vehicle room |
+| `EMBARK vehicle` | Enter the vehicle room |
+| `DRIVE direction` | Move vehicle and occupants |
 | `DISEMBARK` | Exit to current world location |
-| `DRIVE NORTH` | Move vehicle (and occupants) to (5,13) |
 
-### Riding the Turtle
+**Lineage:** Papert's Logo turtle, Don Hopkins' Pie Menus, Will Wright's SimAntics.
 
-**RIDE the turtle.** Move around the room, draw on the floor, jump through doors:
+## Data Flow: Throwing Objects Through Exits
 
-```
-> RIDE turtle
-You mount the turtle. The world scrolls beneath you.
-
-> FORWARD 100
-The turtle moves forward. A red line appears on floor.svg.
-
-> RIGHT 90
-> FORWARD 50
-You're near the door-north.
-
-> ENTER door-north
-You jump through the door INTO the next room.
-The turtle comes with you.
-```
-
-```yaml
-# turtle.yml — a vehicle within room-space
-turtle:
-  position: {x: 100, y: 100}
-  heading: 90  # degrees, 0 = north
-  pen_down: true
-  pen_color: "#e94560"
-  rider: "the-explorer"
-```
-
-| Command | Effect |
-|---------|--------|
-| `RIDE turtle` | Mount the turtle, move with it |
-| `FORWARD 50` | Move forward, draw if pen down |
-| `RIGHT 90` | Turn right |
-| `ENTER door` | Jump through door to connected room |
-| `INTO subroom` | Descend into nested sub-room |
-| `ZOOM OUT` | See the room graph navigator |
-
-**Lineage:** Papert's Logo turtle, Rocky's Boots (1982), Robot Odyssey (1984).
-
-### Snap Cursor & Pie Menus
-
-When you approach an object, the cursor **snaps** to it and shows a **pie menu** of scored actions:
-
-```
-        EXAMINE (80)
-           ╱
- REPAIR ──●── USE (95) ← default
-           ╲
-        TAKE (20)
-```
-
-**This IS The Sims interaction model:**
-- Objects **advertise** their available actions
-- Actions are **scored** based on context, needs, state
-- High-scoring actions appear prominently
-
-**Lineage:** Don Hopkins' [Pie Menus](https://en.wikipedia.org/wiki/Pie_menu) + Will Wright's SimAntics.
-
-## Cursor as Vehicle: Direct Manipulation
-
-The cursor **carries tools** and applies them to the room floor:
-
-```
-> SELECT pen-tool
-Cursor now carries: 🖊️ pen (red)
-
-> CLICK workbench
-*snap* Cursor at workbench. Pen ready.
-
-> DRAG to door-north
-Drawing line from workbench to door-north...
-Line added to floor.svg
-```
-
-| Tool | Icon | Action |
-|------|------|--------|
-| `pen` | 🖊️ | Draw lines on floor |
-| `eraser` | 🧽 | Remove drawings |
-| `selector` | 👆 | Pick up and move objects |
-| `linker` | 🔗 | Draw connections between objects |
-| `stamper` | 📌 | Place copies of cards |
-
-## Throwing Objects: Data Flow Programming
-
-**Throw objects through exits.** They pile up on the other side.
-
-```
-> THROW blueprint door-north
-Throwing blueprint through door-north...
-blueprint landed in assembly/inbox/
-```
-
-### Inbox / Outbox
-
-```
-room/
-  inbox/           # Objects thrown INTO this room land here
-    task-001.yml
-  outbox/          # Stage objects before throwing OUT
-    result-001.yml
-```
+Rooms are **processing nodes**. Throw objects through exits — they land in `inbox/`. Stage outgoing items in `outbox/`.
 
 | Command | Effect |
 |---------|--------|
 | `THROW obj exit` | Toss object through exit |
-| `INBOX` | List waiting items |
-| `NEXT` | Process next item (FIFO) |
-| `STAGE obj exit` | Add to outbox |
-| `FLUSH` | Throw all staged objects |
-
-### Rooms as Pipeline Stages
-
-Each room is a **processing node**. Exits are **edges**. Thrown objects are **messages**.
-
-```yaml
-# Document processing pipeline:
-uploads/          # Raw files land here
-  inbox/
-parser/           # Extract text
-  script: parse.py
-analyzer/         # LLM analyzes  
-  prompt: "Summarize and extract entities"
-output/           # Final results collect here
-```
-
-**This is Kilroy-style data flow:** rooms as nodes, files as messages, the filesystem as the network.
+| `INBOX` / `NEXT` | List or process waiting items |
+| `STAGE obj exit` / `FLUSH` | Stage and send outgoing items |
 
 ## Inventories
 
@@ -476,99 +350,15 @@ notes/
 
 ## Nested Containers
 
-Objects can contain other objects, to arbitrary depth:
-
-```
-> PUT screwdriver IN toolbox
-> PUT toolbox IN backpack
-> OPEN backpack
-backpack contains:
-  - toolbox (3 items)
-  - sandwich
-```
-
-### Object Paths
-
-Address nested objects with paths:
-
-```
-> EXAMINE backpack/toolbox/wrench
-> USE inventory/potions/healing
-> TAKE ../chest/gold FROM here
-```
-
-Path syntax:
-- `container/sub/item` — absolute within scope
-- `./toolbox/wrench` — relative to current
-- `../sibling/item` — parent's sibling
-- `/repo-name/path` — multi-repo addressing
-
-### Tags for Search
-
-```
-> TAG wrench @favorite
-> SEARCH backpack @tool
-Found in backpack:
-  toolbox/screwdriver [@tool]
-  toolbox/wrench [@tool @favorite]
-```
+Objects contain other objects to arbitrary depth. Address with paths: `backpack/toolbox/wrench`, `./relative`, `../sibling`. Tag items with `@tag` for search across containers.
 
 ## Room Graph Navigator
 
-**ZOOM OUT** to see the whole world:
+`ZOOM OUT` to see the whole world graph. `ZOOM IN room` to enter. `LINK a TO b` to create connections. Navigate the structure while editing — like Rocky's Boots.
 
-```
-> ZOOM OUT
-│  ROOM GRAPH: moollm-palace              │
-│       [room] [card] [chat]              │
-│         │                               │
-│      [★ YOU ARE HERE]                   │
+## Speed of Light: Multi-Agent in One Call
 
-> LINK room TO card
-Connection created. You can now JUMP directly.
-```
-
-| Command | Effect |
-|---------|--------|
-| `ZOOM OUT` | See room graph overview |
-| `ZOOM IN room` | Enter selected room |
-| `LINK a TO b` | Create connection between rooms |
-
-**Like Rocky's Boots:** Navigate the structure. Edit while exploring.
-
-## Speed of Light vs Carrier Pigeons
-
-> **Traditional multi-agent**: Each agent in isolation. One LLM call per agent. Communication by carrier pigeon. **Slow. Expensive. Sad.**
-
-> **MOOLLM**: Simulate as many agents together as possible in ONE LLM call. Communication at the speed of light. Multiple simulation steps per iteration.
-
-```yaml
-# In one LLM iteration:
-simulation:
-  - step: 1
-    papert-001: "Microworlds need low floors"
-    kay-001: "Yes! Like Smalltalk for children"
-    
-  - step: 2
-    papert-001: 
-      responds_to: kay-001
-      says: "Exactly! Accessible entry, unlimited ceiling"
-      
-  - step: 3
-    synthesis:
-      emerged: "Low floor + high ceiling + prototypes = MOOLLM"
-```
-
-Three characters, three steps, instant cross-talk — **ONE LLM call**.
-
-### This IS The Sims
-
-```
-The Sims: One frame, all Sims simulated, instant interaction
-MOOLLM:   One call, all cards simulated, instant messaging
-```
-
-Instead of isolated agent prisons, we have a **shared microworld**.
+Simulate multiple agents together in ONE LLM call — instant cross-talk instead of isolated agent prisons. Like The Sims: one frame simulates all characters with instant interaction. See [speed-of-light/](../speed-of-light/) for full protocol.
 
 ## Room Navigation
 
@@ -673,108 +463,11 @@ See [character/](../character/) for party-based code review, README.md for detai
 
 See [naming/](../naming/) for conventions.
 
-## Rooms ARE Logistic Containers!
+## Rooms as Logistic Containers
 
-### The Unification: Sims + Factorio
+Rooms participate in a **logistics network** (Sims + Factorio unification). Rooms advertise needs with attractiveness scores, items route to highest-scoring requester, and bots or belts move items physically. Supports stacking (fungible counts or individual instances) and grid cells for warehouse patterns.
 
-Rooms can participate in a **logistics network**:
-
-| Feature | Source | MOOLLM |
-|---------|--------|--------|
-| Action advertisements | The Sims | Objects advertise what they DO |
-| Item requests | Factorio | Containers advertise what they NEED |
-| Attractiveness scores | Both | Higher score = higher priority |
-
-### Room Logistics Mode
-
-```yaml
-room:
-  name: "The Kitchen"
-  
-  logistics:
-    mode: requester              # passive-provider, requester, buffer...
-    request_list:
-      - tags: ["ingredient"]
-        count: 10
-        priority: high
-```
-
-### Logistic Advertisements
-
-Rooms advertise their NEEDS with attractiveness scores:
-
-```yaml
-logistic_advertisements:
-  
-  NEED_INGREDIENTS:
-    description: "Kitchen needs ingredients"
-    wants:
-      - tags: ["ingredient"]
-        count: 10
-    score: 70                    # Base priority
-    score_if: "chef_is_cooking"  # When to boost
-    score_bonus: 30              # Total 100 when cooking!
-    
-  DESPERATELY_NEED_LIGHT:
-    wants:
-      - tags: ["light-source"]
-        count: 1
-    score: 100                   # Very high!
-```
-
-### Stacking in Rooms
-
-Rooms can have stacks of items:
-
-```yaml
-room:
-  name: "Armory"
-  
-  stacks:
-    # Fungible (just count)
-    arrow: 500
-    bolt: 300
-    
-    # Instance (individual state)
-    magic-sword:
-      count: 3
-      instances:
-        - { id: flame-blade, damage: 50 }
-        - { id: frost-edge, damage: 45 }
-        
-  stack_limit: 1000
-```
-
-### Grid Room Cells
-
-Warehouse rooms can be grid cells:
-
-```yaml
-room:
-  name: "Iron Ore Storage"
-  type: grid-cell
-  
-  grid_cell:
-    enabled: true
-    parent: "../"
-    coordinates: { x: 2, y: 3 }
-    item_type: iron-ore
-    
-  stacks:
-    iron-ore: 2500
-```
-
-### The Flow
-
-```
-1. ROOMS advertise logistic needs with scores
-2. LOGISTICS ENGINE collects all advertisements
-3. Items route to HIGHEST-SCORING requester
-4. BOTS or BELTS move items physically
-5. ROOM receives items, fires on_item_added
-```
-
-See [logistic-container/](../logistic-container/) and [factorio-logistics-protocol.md](../../designs/factorio-logistics-protocol.md).
+See [logistic-container/](../logistic-container/) and [factorio-logistics-protocol.md](../../designs/factorio-logistics-protocol.md) for full specification.
 
 ---
 


### PR DESCRIPTION
Hey @SimHacker 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/8f3d31c5-cd4e-4fb2-93f0-4e333c25ccbc" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| adventure | 0% | 93% | +93% |
| cat | 0% | 79% | +79% |
| character | 0% | 79% | +79% |
| room | 0% | 74% | +74% |
| abstract | 0% | 63% | +63% |

All five skills were scoring 0% due to frontmatter validation errors — the `allowed-tools` field was formatted as a YAML array instead of a comma-separated string, and `abstract` had no frontmatter at all. This PR is intentionally capped at five skills to keep it reviewable; the included workflow (below) will surface Tessl feedback on future `SKILL.md` changes across the rest of your 117-skill library.

<details>
<summary>Changes summary</summary>

**Frontmatter fixes (all 5 skills):**
- Converted `allowed-tools` from YAML array to comma-separated string (the format `tessl skill review` expects)
- Moved non-standard frontmatter keys (`tier`, `protocol`, `lineage`, `inherits`, `related`, `tags`, `templates`, `origin`) into a `metadata` block to clear unknown-key warnings

**Description improvements (all 5 skills):**
- Expanded descriptions with specific trigger terms and explicit "Use when..." clauses
- Descriptions now articulate concrete capabilities rather than just naming the skill

**Skill-specific changes:**
- **abstract**: Added full frontmatter (had none — went from no `---` delimiters to proper name + description)
- **room**: Trimmed from 807 → 499 lines by condensing verbose vehicle, logistics, and data-flow sections into brief summaries with links to related skills. Core room anatomy, regions, and ROOM.yml structure preserved in full

</details>

## Automated Skill Review Workflow

This PR also adds `.github/workflows/skill-review.yml` — a GitHub Action that runs on PRs touching `SKILL.md` files:

- **What runs:** [`tesslio/skill-review`](https://github.com/tesslio/skill-review) detects changed `SKILL.md` files, runs `tessl skill review` on each, and posts (or updates) **one** PR comment with scores and feedback
- **Zero extra accounts:** contributors don't need a Tessl login — only the repo's default `GITHUB_TOKEN` is used to post the comment
- **Non-blocking by default:** the check is feedback-only with no surprise red CI, unless you add `fail-threshold`
- **Not a build replacement:** this is review automation for skill markdown only — it doesn't touch your existing pipelines
- **Optional gate:** add `with: fail-threshold: 70` later if you want PRs to fail on low skill scores
- **Why only five skills here:** this PR stays small and reviewable; after merge, every PR that touches `SKILL.md` gets automatic review comments, so the rest of the library improves incrementally

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
